### PR TITLE
Add basic CI validating lint and build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Setup node 20.x
+      uses: actions/setup-node@v3
+      with:
+          node-version: 20.x
+    - name: Build
+      run: npm i
+    - name: Lint
+      run: npm run lint
+    - name: Bulid
+      run: npm run compile
+    - name: Package
+      run: npm run vscode:prepublish


### PR DESCRIPTION
This patch adds basic CI validating lint and build using Node 20.
It'll be extended with deploying the extension to the marketplace.
