### PR TITLE
Add cluster configuration jsonschema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,18 @@ Tarantool VSCode Extension helps you to develop Tarantool applications in VSCode
 
 Please, note that this extension uses [EmmyLua extension](https://github.com/EmmyLua/VSCode-EmmyLua) as a backend for Tarantool-specific stuff.
 
+## Features
+
+* Language server support and type annotations for Lua.
+* Configuration schema validation.
+
 ## Usage
 
 That's how you use this extension.
 
 * Install he extension from the VSCode marketplace.
 * Open a Tarantool project in VSCode.
-* Run `Initialize Tarantool environment` command from the command palette (`Ctrl+Shift+P`).
-
-## Requirements
-
-If you have any requirements or dependencies, add a section describing those and how to install and configure them.
+* Run `Tarantool: Initialize environment` command from the command palette (`Ctrl+Shift+P`).
 
 ## References
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,13 @@
     "commands": [
       {
         "command": "tarantool-vscode.init",
-        "title": "Initialize Tarantool environment"
+        "title": "Tarantool: Initialize environment"
+      }
+    ],
+    "yamlValidation": [
+      {
+        "fileMatch": [ "cluster.yml", "cluster.yaml", "config.yml", "config.yaml", "source.yml", "source.yaml" ],
+        "url": "https://download.tarantool.org/tarantool/schema/config.schema.json"
       }
     ]
   },
@@ -55,6 +61,7 @@
     "webpack-cli": "^6.0.1"
   },
   "extensionDependencies": [
-    "tangzx.emmylua"
+    "tangzx.emmylua",
+    "redhat.vscode-yaml"
   ]
 }


### PR DESCRIPTION
This patch adds a jsonschema validation for the cluster configuration.
The schema is automatically fetched from [^1].

It is used for `source.yml`, `config.yml`, and `cluster.yml` files and
uses RedHat YAML schema extension.

[^1]: https://download.tarantool.org/tarantool/schema/config.schema.json
[^2]: https://github.com/redhat-developer/vscode-yaml
