### PR TITLE
Add support for TT `start` and `stop` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Please, note that this extension uses [EmmyLua extension](https://github.com/Emm
 
 * Language server support and type annotations for Lua.
 * Configuration schema validation.
+* Using [TT](https://github.com/tarantool/tt) right from the command pallete.
 
 ## Usage
 
@@ -15,11 +16,11 @@ That's how you use this extension.
 
 * Install he extension from the VSCode marketplace.
 * Open a Tarantool project in VSCode.
-* Run `Tarantool: Initialize environment` command from the command palette (`Ctrl+Shift+P`).
+* Run `Tarantool: Initialize VScode extension in existing app` command from the command palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on macOS).
 
 ## References
 
 * [Tarantool](https://www.tarantool.io/)
 * [VSCode Emmylua extension](https://github.com/EmmyLua/VSCode-EmmyLua)
 * [Tarantool EmmyLua annotations](https://github.com/georgiy-belyanin/emmylua-annotations)
-* [Tarantool vscode extension](https://github.com/vaintrub/vscode-tarantool)
+* [Tarantool vscode extension](htlps://github.com/vaintrub/vscode-tarantool)

--- a/package.json
+++ b/package.json
@@ -23,8 +23,20 @@
   "contributes": {
     "commands": [
       {
+        "command": "tarantool-vscode.init-vs",
+        "title": "Tarantool: Initialize VSCode extension in existing app"
+      },
+      {
         "command": "tarantool-vscode.init",
-        "title": "Tarantool: Initialize environment"
+        "title": "Tarantool: Initialize application (tt)"
+      },
+      {
+        "command": "tarantool-vscode.start",
+        "title": "Tarantool: Start cluster (tt)"
+      },
+      {
+        "command": "tarantool-vscode.stop",
+        "title": "Tarantool: Stop cluster (tt)"
       }
     ],
     "yamlValidation": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import * as tt from './tt';
 
 const emmyrc = {
 	"runtime": {
@@ -14,7 +15,7 @@ const emmyrc = {
 };
 
 export function activate(context: vscode.ExtensionContext) {
-	const disposable = vscode.commands.registerCommand('tarantool-vscode.init', () => {
+	context.subscriptions.push(vscode.commands.registerCommand('tarantool-vscode.init-vs', () => {
 		const wsedit = new vscode.WorkspaceEdit();
 		const wsPath = vscode.workspace.workspaceFolders?.at(0)?.uri.fsPath; // gets the path of the first workspace folder
 		if (!wsPath) {
@@ -29,9 +30,11 @@ export function activate(context: vscode.ExtensionContext) {
 		});
 		vscode.workspace.applyEdit(wsedit);
 		vscode.window.showInformationMessage('Created a new file: ' + filePath.toString());
-	});
+	}));
 
-	context.subscriptions.push(disposable);
+	context.subscriptions.push(vscode.commands.registerCommand('tarantool-vscode.init', tt.init));
+	context.subscriptions.push(vscode.commands.registerCommand('tarantool-vscode.start', tt.start));
+	context.subscriptions.push(vscode.commands.registerCommand('tarantool-vscode.stop', tt.stop));
 }
 
 export function deactivate() {}

--- a/src/tt.ts
+++ b/src/tt.ts
@@ -1,0 +1,47 @@
+import * as vscode from 'vscode';
+
+const TerminalLabel = 'Tarantool';
+const Tt = 'tt';
+
+function selectTerminal(): Thenable<vscode.Terminal | undefined> {
+	interface TerminalQuickPickItem extends vscode.QuickPickItem {
+		terminal: vscode.Terminal;
+	}
+	const terminals = vscode.window.terminals;
+	const items: TerminalQuickPickItem[] = terminals.map(t => {
+		return {
+			label: `name: ${t.name}`,
+			terminal: t
+		};
+	});
+	return vscode.window.showQuickPick(items).then(item => {
+		return item ? item.terminal : undefined;
+	});
+}
+
+function getTerminal(): vscode.Terminal {
+	const terminal = vscode.window.terminals.find(t => t.name === TerminalLabel) ||
+		vscode.window.createTerminal(TerminalLabel);
+	terminal.show(true);
+	return terminal;
+}
+
+function isTerminalRunning(): boolean {
+	const terminals = vscode.window.terminals;
+	return terminals.find(t => t.name === TerminalLabel) !== undefined;
+}
+
+export function init() {
+	const t = getTerminal();
+	t.sendText('tt init');
+}
+
+export function start() {
+	const t = getTerminal();
+	t.sendText('tt start -i &');
+}
+
+export function stop() {
+	const t = getTerminal();
+	t.sendText('tt stop -y');
+}


### PR DESCRIPTION
This patch adds a few commands to the command pallete to start and stop
the Tarantool clusters using `tt` utility [^1].

The support is really basic. It can only start and stop the whole
cluster.

[^1]: https://github.com/tarantool/tt.
