### PR TITLE
Add uploading .vsix extension artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,14 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        include:
+         - {target: linux-x64}
+         - {target: linux-arm64}
+         - {target: darwin-x64}
+         - {target: darwin-arm64}
+
     runs-on: ubuntu-latest
 
     steps:
@@ -20,7 +28,10 @@ jobs:
       run: npm i
     - name: Lint
       run: npm run lint
-    - name: Bulid
-      run: npm run compile
     - name: Package
-      run: npm run vscode:prepublish
+      run: npx vsce package -o tarantool-vscode-${{ matrix.target }}.vsix --target ${{ matrix.target }}
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: Tarantool VSCode ${{ matrix.target }}
+        path: ${{ github.workspace }}/tarantool-vscode*.vsix


### PR DESCRIPTION
This patch adds a step to build a .vsix extension and uploads it as an
artifact on a various target OS.
