### PR TITLE
Release 0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 All notable changes to the "tarantool-vscode" extension will be documented in this file.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-- Initial release
+## [0.0.1] - 28.03.2025
+
+### Added
+
+- Added support for EmmyLua LSP and Tarantool-specific annottations.
+- Added jsonschema checks for Tarantool cluster configuration.
+- Added `tt` start and stop commands to the command palette.


### PR DESCRIPTION
This patch adds the changelog for the 0.0.1 release. This commit is
going to be tagged and released as 0.0.1.

Honestly, the changelogs have to be added in the previous patches but
I've forgotten them.
