### PR TITLE
Add restart, status, and install CE commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `tt` restart and status to the command palette.
+- Added `tt` install Tarantool CE to the command palette.
+
+### Changed
+
+- Now the package is called `tarantool` instead of `tarantool-vscode`.
+
 ## [0.0.1] - 28.03.2025
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,18 @@
 {
-  "name": "tarantool-vscode",
+  "name": "tarantool",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tarantool-vscode",
+      "name": "tarantool",
       "version": "0.0.1",
+      "dependencies": {
+        "@octokit/core": "^5",
+        "command-exists": "^1.2.9"
+      },
       "devDependencies": {
+        "@types/command-exists": "^1.2.3",
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",
         "@types/vscode": "^1.98.0",
@@ -412,6 +417,158 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
+      "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "license": "ISC"
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql/node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "license": "ISC"
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -422,6 +579,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/command-exists": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-exists/-/command-exists-1.2.3.tgz",
+      "integrity": "sha512-PpbaE2XWLaWYboXD6k70TcXO/OdOyyRFq5TVpmlUELNxdkkmXU9fkImNosmXU1DtsNrqdUgWd/nJQYXgwmtdXQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -1126,6 +1290,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1545,6 +1715,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -1662,6 +1838,12 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "license": "ISC"
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -3174,7 +3356,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -4710,7 +4891,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,13 @@
         "command": "tarantool.stop",
         "title": "Tarantool: Stop cluster (tt)"
       },
+      {
+        "command": "tarantool.stat",
+        "title": "Tarantool: Get cluster status (tt)"
+      },
+      {
+        "command": "tarantool.restart",
+        "title": "Tarantool: Restart cluster (tt)"
       }
     ],
     "yamlValidation": [

--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
-  "name": "tarantool-vscode",
-  "displayName": "tarantool-vscode",
+  "name": "tarantool",
+  "displayName": "Tarantool VSCode extension",
   "description": "Tarantool VSCode extension.",
   "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/georgiy-belyanin/tarantool-vscode"
+  },
+  "publisher": "tarantool",
   "engines": {
     "vscode": "^1.98.0"
   },
@@ -23,25 +28,33 @@
   "contributes": {
     "commands": [
       {
-        "command": "tarantool-vscode.init-vs",
+        "command": "tarantool.init-vs",
         "title": "Tarantool: Initialize VSCode extension in existing app"
       },
       {
-        "command": "tarantool-vscode.init",
+        "command": "tarantool.init",
         "title": "Tarantool: Initialize application (tt)"
       },
       {
-        "command": "tarantool-vscode.start",
+        "command": "tarantool.start",
         "title": "Tarantool: Start cluster (tt)"
       },
       {
-        "command": "tarantool-vscode.stop",
+        "command": "tarantool.stop",
         "title": "Tarantool: Stop cluster (tt)"
+      },
       }
     ],
     "yamlValidation": [
       {
-        "fileMatch": [ "cluster.yml", "cluster.yaml", "config.yml", "config.yaml", "source.yml", "source.yaml" ],
+        "fileMatch": [
+          "cluster.yml",
+          "cluster.yaml",
+          "config.yml",
+          "config.yaml",
+          "source.yml",
+          "source.yaml"
+        ],
         "url": "https://download.tarantool.org/tarantool/schema/config.schema.json"
       }
     ]
@@ -58,6 +71,7 @@
     "test": "vscode-test"
   },
   "devDependencies": {
+    "@types/command-exists": "^1.2.3",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
     "@types/vscode": "^1.98.0",
@@ -75,5 +89,9 @@
   "extensionDependencies": [
     "tangzx.emmylua",
     "redhat.vscode-yaml"
-  ]
+  ],
+  "dependencies": {
+    "command-exists": "^1.2.9",
+    "@octokit/core": "^5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
       {
         "command": "tarantool.restart",
         "title": "Tarantool: Restart cluster (tt)"
+      },
+      {
+        "command": "tarantool.install-ce",
+        "title": "Tarantool: Install Tarantool Community Edition (tt)"
       }
     ],
     "yamlValidation": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('tarantool.stop', tt.stop));
 	context.subscriptions.push(vscode.commands.registerCommand('tarantool.restart', tt.restart));
 	context.subscriptions.push(vscode.commands.registerCommand('tarantool.stat', tt.stat));
+	context.subscriptions.push(vscode.commands.registerCommand('tarantool.install-ce', tt.installCe));
 }
 
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,3 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 import * as tt from './tt';
 
@@ -32,9 +30,9 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.window.showInformationMessage('Created a new file: ' + filePath.toString());
 	}));
 
-	context.subscriptions.push(vscode.commands.registerCommand('tarantool-vscode.init', tt.init));
-	context.subscriptions.push(vscode.commands.registerCommand('tarantool-vscode.start', tt.start));
-	context.subscriptions.push(vscode.commands.registerCommand('tarantool-vscode.stop', tt.stop));
+	context.subscriptions.push(vscode.commands.registerCommand('tarantool.init', tt.init));
+	context.subscriptions.push(vscode.commands.registerCommand('tarantool.start', tt.start));
+	context.subscriptions.push(vscode.commands.registerCommand('tarantool.stop', tt.stop));
 }
 
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,8 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('tarantool.init', tt.init));
 	context.subscriptions.push(vscode.commands.registerCommand('tarantool.start', tt.start));
 	context.subscriptions.push(vscode.commands.registerCommand('tarantool.stop', tt.stop));
+	context.subscriptions.push(vscode.commands.registerCommand('tarantool.restart', tt.restart));
+	context.subscriptions.push(vscode.commands.registerCommand('tarantool.stat', tt.stat));
 }
 
 export function deactivate() {}


### PR DESCRIPTION
This patchset containts three distinct patches adding a few new `tt` commands to the command pallete.

- The first patch change package name to `tarantool` just as a nice prerequisite.
- The second patch adds quite straightforward `status` and `restart` commands to the command pallete.
- The third patch adds `install` command for installing Tarantool CE based on the tags fetched using octokit.
