### PR TITLE
Add Tarantool icon to the plugin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.png filter=lfs diff=lfs merge=lfs -text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `tt` restart and status to the command palette.
 - Added `tt` install Tarantool CE to the command palette.
+- Added plugin icon.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<a href="http://tarantool.org">
+ <img src="https://avatars2.githubusercontent.com/u/2344919?v=2&s=250" align="right">
+</a>
+
 # 🕷 Tarantool VSCode Extension
 
 Tarantool VSCode Extension helps you to develop Tarantool applications in VSCode. It enchances your text editor with completions, suggestions, and snippets.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "displayName": "Tarantool VSCode extension",
   "description": "Tarantool VSCode extension.",
   "version": "0.0.1",
+  "icon": "res/icon.png",
   "repository": {
     "type": "git",
     "url": "https://github.com/georgiy-belyanin/tarantool-vscode"

--- a/res/icon.png
+++ b/res/icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68436cc2c1c5d6c75738eb222f37a564664dbb8e40b194f4835351317e673508
+size 14126


### PR DESCRIPTION
This patch adds a Tarantool icon to the VS Code plugin and in the
repository README.

Tarantool organization [^1] avatar has been used.

[^1] https://github.com/tarantool
