### PR TITLE
Remove extra files from the bundle

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,3 +12,5 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 **/.vscode-test.*
+.github/**
+.gitmodules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Now the package is called `tarantool` instead of `tarantool-vscode`.
 
+### Fixed
+
+- Removed duplicating `tarantool-emmylua` and GitHub CI from the bundle.
+
 ## [0.0.1] - 28.03.2025
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Now the package is called `tarantool` instead of `tarantool-vscode`.
+- Now the id is `tarantool` instead of `tarantool-vscode` and the package
+  name is simple `Tarantool`.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tarantool",
-  "displayName": "Tarantool VSCode extension",
-  "description": "Tarantool VSCode extension.",
+  "displayName": "Tarantool",
+  "description": "Develop Tarantool applications with ease",
   "version": "0.0.1",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "test": "vscode-test"
   },
   "devDependencies": {
+    "@octokit/core": "^5",
     "@types/command-exists": "^1.2.3",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
@@ -90,6 +91,7 @@
     "@typescript-eslint/parser": "^8.28.0",
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.4.1",
+    "command-exists": "^1.2.9",
     "copy-webpack-plugin": "^13.0.0",
     "eslint": "^9.23.0",
     "ts-loader": "^9.5.2",
@@ -100,9 +102,5 @@
   "extensionDependencies": [
     "tangzx.emmylua",
     "redhat.vscode-yaml"
-  ],
-  "dependencies": {
-    "command-exists": "^1.2.9",
-    "@octokit/core": "^5"
-  }
+  ]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ const emmyrc = {
 	},
 	"workspace": {
 		"library": [
-			__dirname + "/Library"
+			__dirname + "/../tarantool-emmylua/Library"
 		]
 	}
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ const emmyrc = {
 };
 
 export function activate(context: vscode.ExtensionContext) {
-	context.subscriptions.push(vscode.commands.registerCommand('tarantool-vscode.init-vs', () => {
+	context.subscriptions.push(vscode.commands.registerCommand('tarantool.init-vs', () => {
 		const wsedit = new vscode.WorkspaceEdit();
 		const wsPath = vscode.workspace.workspaceFolders?.at(0)?.uri.fsPath; // gets the path of the first workspace folder
 		if (!wsPath) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@
 'use strict';
 
 const path = require('path');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 //@ts-check
 /** @typedef {import('webpack').Configuration} WebpackConfig **/
@@ -22,13 +21,6 @@ const extensionConfig = {
     filename: 'extension.js',
     libraryTarget: 'commonjs2'
   },
-  plugins: [
-    new CopyWebpackPlugin({
-      patterns: [
-        { from: './tarantool-emmylua', to: path.resolve(__dirname, 'dist') }
-      ]
-    })
-  ],
   externals: {
     vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
     // modules added here also need to be added in the .vscodeignore file


### PR DESCRIPTION
This patchset removes extra files from the bundle and fixes a few other small issues.

- The first patch removes extra files from the plugin bundle including GitHub CI configuration and extra EmmyLua files.
- The second patch changes the plugin display name and the description.
- The third patch fixes missing init extension command due to defining it with old `tarantool-vscode` name.
