### PR TITLE
Fix missing Tarantool modules in LSP

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -14,3 +14,4 @@ vsc-extension-quickstart.md
 **/.vscode-test.*
 .github/**
 .gitmodules
+tarantool-emmylua/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `tt` restart and status to the command palette.
 - Added `tt` install Tarantool CE to the command palette.
 - Added plugin icon.
+- Now the extension performs startup checks whether there are Tarantool annotations when it starts.
 
 ### Changed
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,25 @@ async function initVs() {
 	vscode.window.showInformationMessage(`Created a new file: ${filePath.toString()}`);
 }
 
+function checkOnStartup() {
+	function error(message: string) {
+		vscode.window.showErrorMessage(`Error during Tarantool plugin initialization: ${message}. Try reinstalling the extension from the marketplace`);
+		return false;
+	}
+
+	const brokenPaths = annotationsPaths.filter((path) => !fs.existsSync(path));
+	if (brokenPaths.length > 0) {
+		return error(`type annotations are not available at ${brokenPaths.join(', ')}`);
+	}
+
+	return true;
+}
+
 export function activate(context: vscode.ExtensionContext) {
+	if (!checkOnStartup()) {
+		return;
+	}
+
 	const commands = [
 		{ name: 'init-vs', cb: initVs },
 		{ name: 'init', cb: tt.init },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,18 +1,18 @@
 import * as vscode from 'vscode';
 import * as tt from './tt';
+import * as fs from 'fs';
 
+const annotationsPaths = [ __dirname + "/Library" ];
 const emmyrc = {
 	"runtime": {
 		"version": "LuaJIT"
 	},
 	"workspace": {
-		"library": [
-			__dirname + "/../tarantool-emmylua/Library"
-		]
+		"library": annotationsPaths
 	}
 };
 
-function initVs() {
+async function initVs() {
 	const wsedit = new vscode.WorkspaceEdit();
 	const wsPath = vscode.workspace.workspaceFolders?.at(0)?.uri.fsPath;
 	if (!wsPath) {
@@ -20,9 +20,16 @@ function initVs() {
 		return;
 	}
 
-	const filePath = vscode.Uri.file(`${wsPath}/.emmyrc.json`);
+	const emmyrcFile = '.emmyrc.json';
+	const filePath = vscode.Uri.file(`${wsPath}/${emmyrcFile}`);
+	if (fs.existsSync(filePath.fsPath)) {
+		const yes = "Yes";
+		const ask = await vscode.window.showInformationMessage(`It seems like there is an existing LSP configuration in ${emmyrcFile} file. Overwrite it?`, yes, "No");
+		if (ask !== yes)
+			{return;}
+	}
 	wsedit.createFile(filePath, {
-		ignoreIfExists: true,
+		overwrite: true,
 		contents: Buffer.from(JSON.stringify(emmyrc))
 	});
 	vscode.workspace.applyEdit(wsedit);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const path = require('path');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 //@ts-check
 /** @typedef {import('webpack').Configuration} WebpackConfig **/
@@ -21,6 +22,13 @@ const extensionConfig = {
     filename: 'extension.js',
     libraryTarget: 'commonjs2'
   },
+  plugins: [
+    new CopyWebpackPlugin({
+      patterns: [
+        { from: './tarantool-emmylua', to: path.resolve(__dirname, 'dist') }
+      ]
+    })
+  ],
   externals: {
     vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
     // modules added here also need to be added in the .vscodeignore file


### PR DESCRIPTION
This patchset fixes missing Tarantool modules in LSP. Turns out the EmmyLua LSP
isn't able to handle `..` in paths properly.

- The first patch fixes missing non-global Tarantool modules in LSP.
- The second patch adds startup Tarantool annotations file checks.
