### PR TITLE
Add license to the project and a few fixes to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
-All notable changes to the "tarantool-vscode" extension will be documented in this file.
+All notable changes to the "tarantool-vscode" extension will be documented in
+this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -12,12 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `tt` restart and status to the command palette.
 - Added `tt` install Tarantool CE to the command palette.
 - Added plugin icon.
-- Now the extension performs startup checks whether there are Tarantool annotations when it starts.
+- Now the extension performs startup checks whether there are Tarantool
+  annotations when it starts.
 
 ### Changed
 
-- Now the id is `tarantool` instead of `tarantool-vscode` and the package
-  name is simple `Tarantool`.
+- Now the id is `tarantool` instead of `tarantool-vscode` and the package name
+  is simple `Tarantool`.
 
 ### Fixed
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+Copyright 2025 Tarantool authors and contributors
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the following
+conditions are met:
+
+1. Redistributions of source code must retain the above
+   copyright notice, this list of conditions and the
+   following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials
+   provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY AUTHORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+AUTHORS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,27 @@
-<a href="http://tarantool.org">
- <img src="https://avatars2.githubusercontent.com/u/2344919?v=2&s=250" align="right">
-</a>
+# 🕷 Tarantool VS Code Extension
 
-# 🕷 Tarantool VSCode Extension
+<a href="http://tarantool.io">
+ <img src="https://avatars2.githubusercontent.com/u/2344919?v=2&s=100" align="right">
+</a>
 
 Tarantool VS Code Extension helps you to develop Tarantool applications in VS Code. It enhances your text editor with completions, suggestions, and snippets.
 
 Please, note that this extension uses [EmmyLua extension](https://github.com/EmmyLua/VSCode-EmmyLua) as a backend for Tarantool-specific stuff.
 
+---
+
 ## Features
 
-* Language server support and type annotations for Lua.
-* Configuration schema validation.
-* Using [TT](https://github.com/tarantool/tt) right from the command pallete.
+<img src="https://i.postimg.cc/k5cnrtZc/box-commit.gif" width="320" align="right">
+
+This extension offers the following features.
+
+* Static type checks and documentation for the most popular Lua and Tarantool builtin modules.
+* Cluster configuration schema validation for Tarantool 3.0+.
+* [tt cluster management utility](https://github.com/tarantool/tt) inside the command pallete.
+* Other auxiliary commands, e.g. install Tarantool of a specific version right from VS Code.
+
+---
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🕷 Tarantool VSCode Extension
 
-Tarantool VSCode Extension helps you to develop Tarantool applications in VSCode. It enchances your text editor with completions, suggestions, and snippets.
+Tarantool VS Code Extension helps you to develop Tarantool applications in VS Code. It enhances your text editor with completions, suggestions, and snippets.
 
 Please, note that this extension uses [EmmyLua extension](https://github.com/EmmyLua/VSCode-EmmyLua) as a backend for Tarantool-specific stuff.
 
@@ -18,13 +18,13 @@ Please, note that this extension uses [EmmyLua extension](https://github.com/Emm
 
 That's how you use this extension.
 
-* Install he extension from the VSCode marketplace.
-* Open a Tarantool project in VSCode.
-* Run `Tarantool: Initialize VScode extension in existing app` command from the command palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on macOS).
+* Install the extension from the VS Code marketplace.
+* Open a Tarantool project in VS Code.
+* Run `Tarantool: Initialize VS Code extension in existing app` command from the command palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on macOS).
 
 ## References
 
 * [Tarantool](https://www.tarantool.io/)
-* [VSCode Emmylua extension](https://github.com/EmmyLua/VSCode-EmmyLua)
-* [Tarantool EmmyLua annotations](https://github.com/georgiy-belyanin/emmylua-annotations)
-* [Tarantool vscode extension](htlps://github.com/vaintrub/vscode-tarantool)
+* [VS Code Emmylua extension](https://github.com/EmmyLua/VSCode-EmmyLua)
+* [Tarantool EmmyLua annotations](https://github.com/georgiy-belyanin/tarantool-emmylua)
+* [Original Tarantool VS Code annotations](https://github.com/vaintrub/vscode-tarantool)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ local unnamed_user = { name = 'Unnamed' }
 
 For more examples, refer to [Emmylua documentation](https://emmylua.github.io/annotation.html).
 
+## Contributing
+
+Feel free to open issues on feature requests, wrong type annotations and bugs. If you're dealing with the problem related to LSP we'd appreciate addressing a direct issue to [emmylua-analyzer-rust](https://github.com/CppCXY/emmylua-analyzer-rust) which is used as a language server.
+
+We also appreciate contributions via pull requests.
+
+Thank you for your interest in Tarantool and its development tools!
+
 ## References
 
 * [Tarantool](https://www.tarantool.io/)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,27 @@ That's how you use this extension.
 * Open a Tarantool project in VS Code.
 * Run `Tarantool: Initialize VS Code extension in existing app` command from the command palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on macOS).
 
+You may statically type your Lua functions as follows.
+
+```lua
+---@class user_info
+---@field name string User's name.
+---@field age? number User's age (optional).
+
+---@alias user_tuple [string, number]
+
+---@param tuples user_tuple[]
+---@return user_info[]
+local function deflatten_users(tuples)
+    -- ...
+end
+
+---@type user_info
+local unnamed_user = { name = 'Unnamed' }
+```
+
+For more examples, refer to [Emmylua documentation](https://emmylua.github.io/annotation.html).
+
 ## References
 
 * [Tarantool](https://www.tarantool.io/)


### PR DESCRIPTION
This patchset adds BSD-3-Clause license and adds a few formatting and
prettifying fixes to the readme.

1. Change to VS Code and fix typos in the README.
2. Add gif displaying the doc feature into the README.
3. dd example on your own types to the readme.
4. Fix changelog width to 80 columns.
5. Add BSD-3-Clause license.
6. Add contributing section to the readme.
