### PR TITLE
Add command for creating Tarantool apps from the templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added plugin icon.
 - Now the extension performs startup checks whether there are Tarantool
   annotations when it starts.
+- Added `tt` create command for creating Tarantool projects from a template.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 Tarantool VS Code Extension helps you to develop Tarantool applications in VS Code. It enhances your text editor with completions, suggestions, and snippets.
 
-Please, note that this extension uses [EmmyLua extension](https://github.com/EmmyLua/VSCode-EmmyLua) as a backend for Tarantool-specific stuff.
-
 ---
 
 ## Features
@@ -62,6 +60,6 @@ Thank you for your interest in Tarantool and its development tools!
 
 ## References & acknowledgments
 
-This is an extension for the [Tarantool database](https://www.tarantool.io/) internally using [VS Code EmmyLua extension used as a language server](https://github.com/EmmyLua/VSCode-EmmyLua).
+This is an extension for the [Tarantool database](https://www.tarantool.io/) internally using [VS Code EmmyLua extension as a language server](https://github.com/EmmyLua/VSCode-EmmyLua).
 
 A lot of the initial work has been done by Tarantool community in the [original Tarantool VS Code annotations](https://github.com/vaintrub/vscode-tarantool).

--- a/package.json
+++ b/package.json
@@ -34,7 +34,11 @@
       },
       {
         "command": "tarantool.init",
-        "title": "Tarantool: Initialize application (tt)"
+        "title": "Tarantool: Initialize tt environment (tt)"
+      },
+      {
+        "command": "tarantool.create",
+        "title": "Tarantool: Create a new app from a template (tt)"
       },
       {
         "command": "tarantool.start",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,6 +57,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	const commands = [
 		{ name: 'init-vs', cb: initVs },
+		{ name: 'create', cb: tt.create },
 		{ name: 'init', cb: tt.init },
 		{ name: 'start', cb: tt.start },
 		{ name: 'stop', cb: tt.stop },

--- a/src/tt.ts
+++ b/src/tt.ts
@@ -45,3 +45,22 @@ export const installCe = async () => {
 		vscode.window.showErrorMessage(`Unable to install Tarantool Community Edition: ${err.message}`);
 	}
 };
+export const create = async () => {
+	const templateList = [
+		{ name: 'single_instance', title: 'Single Instance (Tarantool 3.x)' },
+		{ name: 'vshard_cluster', title: 'Vshard cluster (Tarantool 3.x)' },
+		{ name: 'cartridge', title: 'Cartridge (Tarantool 2.x)' }
+	];
+
+	const templateTitles = templateList.map((template) => template.title);
+	const templateTitle = await vscode.window.showQuickPick(templateTitles, { placeHolder: 'Select a template' });
+	if (!templateTitle) {return;}
+
+	const templateName = templateList.find((template) => template.title === templateTitle)?.name;
+	if (!templateName) {return;}
+
+	const name = await vscode.window.showInputBox({ prompt: 'Enter a name for your app' });
+	if (!name) {return;}
+
+	cmd(`create ${templateName} --name ${name}`)();
+};


### PR DESCRIPTION
This patch adds a command for creating Tarantool projects from the templates
using `tt create`

- The first patch removes. the LSP info from the README beginning.
- The second patch adds `tt` create from the template command.
