### PR TITLE
Don't use tarantool-emmylua as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/tarantool-emmylua"]
-	path = tarantool-emmylua
-	url = https://github.com/georgiy-belyanin/tarantool-emmylua/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -14,5 +14,5 @@ vsc-extension-quickstart.md
 **/.vscode-test.*
 .github/**
 .gitmodules
-tarantool-emmylua/**
+tarantool-annotations/**
 examples/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Now the id is `tarantool` instead of `tarantool-vscode` and the package name
   is simple `Tarantool`.
 - Tarantool annotations aren't longer used as a submodule.
+- Now initialize the extension command also tries to initialize the extension
+  in the workspace folder in which the opened file is located.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Now the id is `tarantool` instead of `tarantool-vscode` and the package name
   is simple `Tarantool`.
+- Tarantool annotations aren't longer used as a submodule.
 
 ### Fixed
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,10 +13,18 @@ const emmyrc = {
 };
 
 async function initVs() {
+	const file = vscode.window.activeTextEditor?.document.uri.fsPath;
+
 	const wsedit = new vscode.WorkspaceEdit();
-	const wsPath = vscode.workspace.workspaceFolders?.at(0)?.uri.fsPath;
+	const wsFolders = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath);
+	if (!wsFolders) {
+		vscode.window.showWarningMessage('Please, open a project before running this command');
+		return;
+	}
+	
+	const wsPath = file ? wsFolders.find((folder) => file.startsWith(folder)) : wsFolders.at(0);
 	if (!wsPath) {
-		vscode.window.showWarningMessage('Please, open project before running this command');
+		vscode.window.showWarningMessage('Please, open at least one folder within the workspace');
 		return;
 	}
 

--- a/tarantool-annotations/LICENSE
+++ b/tarantool-annotations/LICENSE
@@ -1,0 +1,28 @@
+Copyright 2025
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the following
+conditions are met:
+
+1. Redistributions of source code must retain the above
+   copyright notice, this list of conditions and the
+   following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials
+   provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY AUTHORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+AUTHORS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/tarantool-annotations/Library/box.lua
+++ b/tarantool-annotations/Library/box.lua
@@ -1,0 +1,565 @@
+---@meta
+
+---# Builtin `box` module
+---
+---As well as executing Lua chunks or defining your own functions, you can exploit Tarantool's storage functionality with the `box` module and its submodules.
+---
+---Every submodule contains one or more Lua functions. A few submodules contain members as well as functions. The functions allow data definition (create alter drop), data manipulation (insert delete update upsert select replace), an introspection (inspecting contents of spaces, accessing server configuration).
+---
+---To catch errors that functions in `box` submodules may throw, use `pcall()`.
+box = {}
+
+--- If a transaction is in progress (for example the user has called [`box.begin()`](lua://box.begin) and has not yet called either [`box.begin()`](lua://box.begin) or [`box.rollback()`](lua://box.rollback), return `true`. Otherwise return `false`.
+---
+---@return boolean is_in_txn
+function box.is_in_txn() end
+
+---@alias box.txn_isolation
+---| 'best-effort'
+---| 'read-committed'
+---| 'read-confirmed'
+---| 'linearizable'
+
+---@class box.begin_options
+---@field txn_isolation? box.txn_isolation the transaction isolation level (default: best-effort)
+---@field timeout? (in_seconds) Number a timeout, after which the transaction is rolled back
+
+---Begin the transaction.
+---
+---Disable implicit yields until the transaction ends.
+---Signal that writes to the write-ahead log will be deferred until the transaction ends.
+---In effect the fiber which executes `box.begin()` is starting an "active multi-request transaction", blocking all other fibers.
+---
+---**Possible errors:**
+---* Error if this operation is not permitted because there is already an active transaction.
+---* Error if for some reason memory cannot be allocated.
+---* Error and abort the transaction if the timeout is exceeded.
+---
+---@param opts? box.begin_options
+function box.begin(opts) end
+
+---End the transaction, and make all its data-change operations permanent.
+---
+---**Possible errors:**
+---* Error and abort the transaction in case of a conflict.
+---* Error if the operation fails to write to disk.
+---* Error if for some reason memory cannot be allocated.
+---
+---**Example:**
+---
+--- ```lua
+--- -- Insert test data --
+--- box.space.bands:insert { 1, 'Roxette', 1986 }
+--- box.space.bands:insert { 2, 'Scorpions', 1965 }
+--- box.space.bands:insert { 3, 'Ace of Base', 1987 }
+---
+--- -- Begin and commit the transaction explicitly --
+--- box.begin()
+--- box.space.bands:insert { 4, 'The Beatles', 1960 }
+--- box.space.bands:replace { 1, 'Pink Floyd', 1965 }
+--- box.commit()
+---
+--- -- Begin the transaction with the specified isolation level --
+--- box.begin({ txn_isolation = 'read-committed' })
+--- box.space.bands:insert { 5, 'The Rolling Stones', 1962 }
+--- box.space.bands:replace { 1, 'The Doors', 1965 }
+--- box.commit()
+--- ```
+function box.commit() end
+
+---End the transaction, but cancel all its data-change operations.
+---
+---An explicit call to functions outside `box.space` that always yield, such as `fiber.sleep()` or `fiber.yield()`, will have the same effect.
+---
+---**Example:**
+---
+--- ```lua
+--- -- Insert test data --
+--- box.space.bands:insert { 1, 'Roxette', 1986 }
+--- box.space.bands:insert { 2, 'Scorpions', 1965 }
+--- box.space.bands:insert { 3, 'Ace of Base', 1987 }
+---
+--- -- Rollback the transaction --
+--- box.begin()
+--- box.space.bands:insert { 4, 'The Beatles', 1960 }
+--- box.space.bands:replace { 1, 'Pink Floyd', 1965 }
+--- box.rollback()
+--- ```
+function box.rollback() end
+
+--TODO: BoxError не хватает корректной обработки
+
+---@class box.savepoint: table
+
+---Return a descriptor of a savepoint, which can be used later by `box.rollback_to_savepoint(savepoint)`.
+---
+---Savepoints can only be created while a transaction is active, and they are destroyed when a transaction ends
+---
+---**Possible errors:**
+---* Error if for some reason memory cannot be allocated.
+---
+---**Example:**
+---
+--- ```lua
+--- -- Insert test data --
+--- box.space.bands:insert { 1, 'Roxette', 1986 }
+--- box.space.bands:insert { 2, 'Scorpions', 1965 }
+--- box.space.bands:insert { 3, 'Ace of Base', 1987 }
+---
+--- -- Rollback the transaction to a savepoint --
+--- box.begin()
+--- box.space.bands:insert { 4, 'The Beatles', 1960 }
+--- save1 = box.savepoint()
+--- box.space.bands:replace { 1, 'Pink Floyd', 1965 }
+--- box.rollback_to_savepoint(save1)
+--- box.commit()
+--- ```
+---
+---@return box.savepoint | box.error savepoint
+function box.savepoint() end
+
+---Do not end the transaction, but cancel all its data-change and [`box.savepoint()`](lua://box.savepoint) operations that were done after the specified savepoint.
+---
+---**Possible errors:**
+---* Error if the savepoint does not exist.
+---
+---**Example:**
+---
+--- ```lua
+--- -- Insert test data --
+--- box.space.bands:insert { 1, 'Roxette', 1986 }
+--- box.space.bands:insert { 2, 'Scorpions', 1965 }
+--- box.space.bands:insert { 3, 'Ace of Base', 1987 }
+---
+--- -- Rollback the transaction to a savepoint --
+--- box.begin()
+--- box.space.bands:insert { 4, 'The Beatles', 1960 }
+--- save1 = box.savepoint()
+--- box.space.bands:replace { 1, 'Pink Floyd', 1965 }
+--- box.rollback_to_savepoint(save1)
+--- box.commit()
+--- ```
+---
+---@param savepoint box.savepoint
+---@return box.error? error
+function box.rollback_to_savepoint(savepoint) end
+
+---Execute a function, acting as if the function starts with an implicit [`box.begin()`](lua://box.begin) and ends with an implicit [`box.commit()`](lua://box.commit) if successful, or ends with an implicit [`box.rollback()`](lua://box.rollback) if there is an error.
+---
+---*Since 2.10.1*
+---
+---**Possible errors:**
+---* Error and abort the transaction in case of a conflict.
+---* Error and abort the transaction if the timeout is exceeded.
+---* Error if the operation fails to write to disk.
+---* Error if for some reason memory cannot be allocated.
+---
+---**Example:**
+---
+--- ```lua
+--- -- Create an index with the specified sequence --
+--- box.schema.sequence.create('id_sequence', { min = 1 })
+--- box.space.bands:create_index('primary', { parts = { 'id' }, sequence = 'id_sequence' })
+---
+--- -- Insert test data --
+--- box.space.bands:insert { 1, 'Roxette', 1986 }
+--- box.space.bands:insert { 2, 'Scorpions', 1965 }
+--- box.space.bands:insert { 3, 'Ace of Base', 1987 }
+---
+--- -- Define a function --
+--- local function insert_band(band_name, year)
+---     box.space.bands:insert { nil, band_name, year }
+--- end
+---
+--- -- Begin and commit the transaction implicitly --
+--- box.atomic(insert_band, 'The Beatles', 1960)
+---
+--- -- Begin the transaction with the specified isolation level --
+--- box.atomic({ txn_isolation = 'read-committed' },
+---         insert_band, 'The Rolling Stones', 1962)
+--- ```
+---
+---@generic T, R
+---@param opts { txn_isolation?: box.txn_isolation }
+---@param tx_function? fun(...: T...): R...
+---@param ... T...
+---@return R... retvals The result of the function passed to `atomic()` as an argument.
+---@overload fun(tx_function: fun(...: T...): R..., ...: T...): R...
+function box.atomic(opts, tx_function, ...) end
+
+---@alias box.on_commit_iterator fun():(number, box.tuple|nil, box.tuple|nil, number) request_id, old_tuple, new_tuple, space_id
+---@alias box.on_commit_trigger_func fun(iterator: box.on_commit_iterator?)
+
+---Define a trigger for execution when a transaction ends due to an event such as [`box.commit()`](lua://box.commit).
+---
+---The trigger function may take an iterator parameter, as described in an example for this section.
+---
+---The trigger function should not access any database spaces.
+---
+---If the trigger execution fails and raises an error, the effect is severe and should be avoided -- use Lua's `pcall()` mechanism around code that might fail.
+---
+---`box.on_commit()` must be invoked within a transaction, and the trigger ceases to exist when the transaction ends.
+---
+---If the parameters are `(nil, old-trigger-function)`, then the old trigger is deleted.
+---
+---Details about trigger characteristics are in the [triggers](doc://triggers-box_triggers) section.
+---
+---**Examples:**
+---
+--- ```lua
+--- -- Insert test data --
+--- box.space.bands:insert { 1, 'Roxette', 1986 }
+--- box.space.bands:insert { 2, 'Scorpions', 1965 }
+--- box.space.bands:insert { 3, 'Ace of Base', 1987 }
+---
+--- -- Define a function called on commit --
+--- function print_commit_result()
+---     print('Commit happened')
+--- end
+---
+--- -- Commit the transaction --
+--- box.begin()
+--- box.space.bands:insert { 4, 'The Beatles', 1960 }
+--- box.on_commit(print_commit_result)
+--- box.commit()
+--- ```
+---
+---The function parameter can be an iterator.
+---
+---The iterator goes through the effects of every request that changed a space
+---during the transaction.
+---
+---The iterator has:
+---* An ordinal request number.
+---* The old value of the tuple before the request (`nil` for an `insert` request).
+---* The new value of the tuple after the request (`nil` for a `delete` request).
+---* The ID of the space.
+---
+---The example below displays the effects of two `replace` requests:
+---
+--- ```lua
+--- -- Insert test data --
+--- box.space.bands:insert { 1, 'Roxette', 1986 }
+--- box.space.bands:insert { 2, 'Scorpions', 1965 }
+--- box.space.bands:insert { 3, 'Ace of Base', 1987 }
+---
+--- -- Define a function called on commit --
+--- function print_replace_details(iterator)
+---     for request_number, old_tuple, new_tuple, space_id in iterator() do
+---         print('request_number: ' .. tostring(request_number))
+---         print('old_tuple: ' .. tostring(old_tuple))
+---         print('new_tuple: ' .. tostring(new_tuple))
+---         print('space_id: ' .. tostring(space_id))
+---     end
+--- end
+---
+--- -- Commit the transaction --
+--- box.begin()
+--- box.space.bands:replace { 1, 'The Beatles', 1960 }
+--- box.space.bands:replace { 2, 'The Rolling Stones', 1965 }
+--- box.on_commit(print_replace_details)
+--- box.commit()
+--- ```
+---
+---The output might look like this:
+---
+--- ```console
+--- request_number: 1
+--- old_tuple: [1, 'Roxette', 1986]
+--- new_tuple: [1, 'The Beatles', 1960]
+--- space_id: 512
+--- request_number: 2
+--- old_tuple: [2, 'Scorpions', 1965]
+--- new_tuple: [2, 'The Rolling Stones', 1965]
+--- space_id: 512
+--- ```
+---
+---@param trigger_func box.on_commit_trigger_func
+---@param old_trigger_func? box.on_commit_trigger_func
+function box.on_commit(trigger_func, old_trigger_func) end
+
+---Define a trigger for execution when a transaction ends due to an event such as [`box.rollback()`](lua://box.rollback).
+---
+---The parameters and warnings are exactly the same as for [`box.on_commit`](lua://box.on_commit).
+---
+---@see box.on_commit
+---
+---@param trigger_func box.on_commit_trigger_func
+---@param old_trigger_func? box.on_commit_trigger_func
+function box.on_commit(trigger_func, old_trigger_func) end
+
+---@alias box.iterator {
+---     iterator: "GE" | "GT" | "LT" | "LE" | "EQ" | "REQ" | "BITS_ALL_NOT_SET" | "BITS_ALL_SET" | "BITS_ANY_SET" | "OVERLAPS" | "NEIGHBOR" | "ALL" | box.index.iterator,
+---     after?: string
+---}
+
+---@enum box.index.iterator
+box.index = {
+    EQ = 0,
+    REQ = 1,
+    ALL = 2,
+    LT = 3,
+    LE = 4,
+    GE = 5,
+    GT = 6,
+    BITS_ALL_SET = 7,
+    BITS_ANY_SET = 8,
+    BITS_ALL_NOT_SET = 9,
+    OVERLAPS = 10,
+    NEIGHBOR = 11,
+    NP = 12,
+    PP = 13,
+}
+
+---Execute a function, provided it has not been executed before.
+---
+---A passed value is checked to see whether the function has already been executed. If it has been executed before, nothing happens. If it has not been executed before, the function is invoked.
+---
+---See an example of using `box.once()` [vshard quick start storage code](doc://vshard-quick-start-storage-code).
+---
+---**Warning:** If an error occurs inside `box.once()` when initializing a database, you can re-execute the failed `box.once()` block without stopping the database. The solution is to delete the `once` object from the system space [`box.space._schema](lua://box.space._schema).
+---
+---Say `box.space._schema:select{}`, find your `once` object there and delete it.
+---
+---When `box.once()` is used for initialization, it may be useful to wait until the database is in an appropriate state (read-only or read-write). In that case, see the functions in the [`box.ctl`](lua://box.ctl).
+---
+---**Note:**
+---
+---The parameter `key` will be stored in the [`_schema`](lua://box.space._schema) system space after `box.once()` is called in order to prevent a double run.
+---
+---These keys are global per replica set. So a simultaneous call of `box.once()` with the same key on two instances of the same replica set may succeed on both of them, but it'll lead to a transaction conflict.
+---
+---**Example:**
+---
+---The example shows how to re-execute the `box.once()` block that contains the `hello` key.
+---
+---First, check the `_schema` system space.
+---The `_schema` space in the example contains two `box.once` objects -- `oncebye` and `oncehello`:
+---
+--- ```tarantoolsession
+--- app:instance001> box.space._schema:select{}
+--- ---
+--- - - ['oncebye']
+--- - ['oncehello']
+--- - ['replicaset_name', 'replicaset001']
+--- - ['replicaset_uuid', '72d2d9bf-5d9f-48c4-ba80-9d657e128fee']
+--- - ['version', 3, 1, 0]
+--- ```
+---
+---Delete the `oncehello` object:
+---
+--- ```tarantoolsession
+--- app:instance001> box.space._schema:delete('oncehello')
+--- ---
+--- - ['oncehello']
+--- ...
+--- ```
+---
+---After that, check the `_schema` space again:
+---
+--- ```tarantoolsession
+---
+--- app:instance001> box.space._schema:select{}
+--- ---
+--- - - ['oncebye']
+--- - ['replicaset_name', 'replicaset001']
+--- - ['replicaset_uuid', '72d2d9bf-5d9f-48c4-ba80-9d657e128fee']
+--- - ['version', 3, 1, 0]
+--- ...
+---
+--- ```
+---
+---To re-execute the function, call the `box.once()` method again:
+---
+--- ```tarantoolsession
+--- app:instance001> box.once('hello', function() end)
+--- ---
+--- ...
+---
+--- app:instance001> box.space._schema:select{}
+--- ---
+--- - - ['oncebye']
+--- - ['oncehello']
+--- - ['replicaset_name', 'replicaset001']
+--- - ['replicaset_uuid', '72d2d9bf-5d9f-48c4-ba80-9d657e128fee']
+--- - ['version', 3, 1, 0]
+--- ...
+---
+--- ```
+---
+---@generic T, R
+---@param key string a value that will be checked
+---@param fnc fun(...: T...): R... function to be executed
+---@param ... T... arguments to the function
+---@return R...
+function box.once(key, fnc, ...) end
+
+---Creates new snapshot of the data and executes checkpoint.gc process
+---
+---Take a snapshot of all data and store it in [`snapshot.dir`](doc://configuration_reference_snapshot_dir)
+---
+---To take a snapshot, Tarantool first enters the delayed garbage collection mode for all data. In this mode, the [Tarantool garbage collector](doc://cfg_checkpoint_daemon-garbage-collector) will not remove files which were created before the snapshot started, it will not remove them until the snapshot has finished. To preserve consistency of the primary key, used to iterate over tuples, a copy-on-write technique is employed. If the master process changes part of a primary key, the corresponding process page is split, and the snapshot process obtains an old copy of the page.
+---
+---In effect, the snapshot process uses multi-version concurrency control in order to avoid copying changes which are superseded while it is running.
+---
+---Since a snapshot is written sequentially, you can expect a very high write performance (averaging to 80MB/second on modern disks), which means an average database instance gets saved in a matter of minutes.
+---
+---You may restrict the speed by changing [`snapshot.snap_io_rate_limit`](doc://configuration_reference_snapshot_snap_io_rate_limit).
+---
+---**Note:**
+---
+---As long as there are any changes to the parent index memory through concurrent updates, there are going to be page splits, and therefore you need to have some extra free memory to run this command. 10% of [`memtx_memory`](doc://cfg_storage-memtx_memory) is, on average, sufficient.
+---
+---This statement waits until a snapshot is taken and returns operation result.
+---
+---**Note:**
+---
+---**Change notice:** Prior to Tarantool version 1.6.6, the snapshot process caused a fork, which could cause occasional latency spikes. Starting with Tarantool version 1.6.6, the snapshot process creates a consistent read view and this view is written to the snapshot file by a separate thread (the "Write Ahead Log" thread).
+---
+---Although `box.snapshot()` does not cause a fork, there is a separate fiber which may produce snapshots at regular intervals -- see the discussion of the [checkpoint daemon](doc://configuration_persistence_checkpoint_daemon).
+---
+--- **Example:**
+---
+--- ```tarantoolsession
+--- tarantool> box.info.version
+--- ---
+--- - 1.7.0-1216-g73f7154
+--- ...
+--- tarantool> box.snapshot()
+--- ---
+--- - ok
+--- ...
+--- tarantool> box.snapshot()
+--- ---
+--- - error: can't save snapshot, errno 17 (File exists)
+--- ...
+--- ```
+---
+---Taking a snapshot does not cause the server to start a new write-ahead log.
+---
+---Once a snapshot is taken, old WALs can be deleted as long as all replicated data is up to date. But the WAL which was current at the time `box.snapshot()` started must be kept for recovery, since it still contains log records written after the start of `box.snapshot()`.
+---
+---An alternative way to save a snapshot is to send a SIGUSR1 signal to the instance.
+---
+---While this approach could be handy, it is not recommended for use in automation: a signal provides no way to find out whether the snapshot was taken successfully or not.
+---
+---**Vinyl:**
+---
+---In vinyl, inserted data is stacked in memory until the limit, set in the [`vinyl_memory`](cfg_storage-vinyl_memory) parameter, is reached. Then vinyl automatically dumps it to the disc. `box.snapshot()` forces this dump in order to have the ability to recover from this checkpoint.
+---
+---The snapshot files are stored in `{space_id}/{index_id}/*.run`.
+---
+---Thus, strictly all the data that was written at the time of LSN of the checkpoint is in the `*.run` files on the disk, and all operations that happened after the checkpoint will be written in the `*.xlog`. All dump files created by `box.snapshot()` are consistent and have the same LSN as checkpoint.
+---
+---At the checkpoint vinyl also rotates the metadata log `*.vylog`, containing data manipulation operations like "create file" and "delete file". It goes through the log, removes duplicating operations from the memory and creates a new `*.vylog` file, giving it the name according to the [vclock](doc://box_introspection-box_info) of the new checkpoint, with "create" operations only. This procedure cleans `*.vylog` and is useful for recovery because the name of the log is the same as the checkpoint signature.
+---
+---@async
+function box.snapshot() end
+
+---@class box.watcher
+local watcher = {}
+
+---unregisters the watcher
+function watcher:unregister() end
+
+---Update the value of a particular key and notify all key watchers of the update.
+---
+---*Since 2.10.0*
+---
+---**Possible errors:**
+---
+---* The value can't be encoded as MsgPack.
+---* The key refers to a ``box.`` system event
+---
+---**Example:**
+---
+--- ```
+--- -- Broadcast value 42 for the 'foo' key.
+--- box.broadcast('foo', 42)
+--- ```
+---
+---@param key string
+---@param value any
+function box.broadcast(key, value) end
+
+---Subscribe to events broadcast by a local host.
+---
+---*Since 2.10.0*
+---
+---To read more about watchers, see the [Functions for watchers](doc://box-watchers) section.
+---
+---**Note:**
+---
+---Keep in mind that garbage collection of a watcher handle doesn't lead to the watcher's destruction. In this case, the watcher remains registered.
+---
+---It is okay to discard the result of `watch` function if the watcher will never be unregistered.
+---
+---**Example:**
+---
+--- ```lua
+--- -- Broadcast value 42 for the 'foo' key.
+--- box.broadcast('foo', 42)
+---
+--- local log = require('log')
+--- -- Subscribe to updates of the 'foo' key.
+--- local w = box.watch('foo', function(key, value)
+---     assert(key == 'foo')
+---     log.info("The box.id value is '%d'", value)
+--- end)
+--- ```
+---
+---If you don't need the watcher anymore, you can unregister it using the command below:
+---
+--- ```lua
+--- w:unregister()
+--- ```
+---
+---@param key string
+---@param func fun(key: string, value: any)
+---@return box.watcher
+function box.watch(key, func) end
+
+---Subscribe once to events broadcast by a local host.
+---
+---*Since 2.10.0*
+---
+---Returns the current value of a given notification key.
+---
+---The function can be used as an alternative to [`box.watch()`](lua://box-watch) when the caller only needs the current value without subscribing to future changes.
+---
+---To read more about watchers, see the [box.watchers](lua://box.watchers) section.
+---
+---**Example:**
+---
+--- ```lua
+---
+--- -- Broadcast value 42 for the 'foo' key.
+--- box.broadcast('foo', 42)
+---
+--- -- Get the value of this key
+--- tarantool> box.watch_once('foo')
+--- ---
+--- - 42
+--- ...
+---
+--- -- Non-existent keys' values are empty
+--- tarantool> box.watch_once('none')
+--- ---
+--- ...
+--- ```
+---
+---@param key string
+---@param func fun(key: string, value: any)
+---@return box.watcher
+function box.watch_once(key, func) end
+
+---@alias box.update_operation
+---| '+' # Addition. Values must be numeric, e.g. unsigned or decimal.
+---| '-' # Subtraction. Values must be numeric.
+---| '&' # Bitwise AND. Values must be unsigned numeric.
+---| '|' # Bitwise OR. Values must be unsigned numeric.
+---| '^' # Bitwise XOR. Values must be unsigned numeric.
+---| ':' # String splice.
+---| '!' # Insertion of a new field.
+---| '#' # Deletion.
+---| '=' # Assignment.

--- a/tarantool-annotations/Library/box/backup.lua
+++ b/tarantool-annotations/Library/box/backup.lua
@@ -1,0 +1,36 @@
+---@meta
+
+---# Builting `box.backup` submodule
+---
+---The `box.backup` submodule contains two functions that are helpful for [backup](doc://admin-backups) in certain situations.
+box.backup = {}
+
+---Informs the server that activities related to the removal of outdated backups must be suspended.
+---
+---To guarantee an opportunity to copy these files, Tarantool will not delete them.
+---But there will be no read-only mode and checkpoints will continue by schedule as usual.
+---
+---Informs the server that activities related to the removal of outdated backups must be suspended.
+---
+---To guarantee an opportunity to copy these files, Tarantool will not delete them. But there will be no read-only mode and checkpoints will continue by schedule as usual.
+---
+---**Return:** a table with the names of snapshot and vinyl files that should be copied
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> box.backup.start()
+--- ---
+--- - - ./00000000000000000015.snap
+--- - ./00000000000000000000.vylog
+--- - ./513/0/00000000000000000002.index
+--- - ./513/0/00000000000000000002.run
+--- ...
+--- ```
+---
+---@param n? number *Since Tarantool 1.10.1* an argument that indicates the checkpoint to use relative to the latest checkpoint. For example `n = 0` means "backup will be based on the latest checkpoint", `n = 1` means "backup will be based on the first checkpoint before the latest checkpoint (counting backwards)", and so on. The default value for n is zero.
+---@return string[]
+function box.backup.start(n) end
+
+---Informs the server that normal operations may resume.
+function box.backup.stop() end

--- a/tarantool-annotations/Library/box/cfg.lua
+++ b/tarantool-annotations/Library/box/cfg.lua
@@ -1,0 +1,131 @@
+---@meta
+
+---@alias box.cfg.election_mode
+---| 'candidate'
+---| 'off'
+---| 'voter'
+
+---@alias box.cfg.log_level
+---| 1 # SYSERROR
+---| 2 # ERROR
+---| 3 # CRITICAL
+---| 4 # WARNING
+---| 5 # INFO
+---| 6 # VERBOSE
+---| 7 # DEBUG
+
+---@alias box.cfg.log
+---| 'file: '
+---| 'pipe: '
+---| 'syslog:identity= '
+---| 'syslog:facility= '
+---| 'syslog:identity= ,facility= '
+---| 'syslog:server= '
+
+---@alias box.cfg.log_format
+---| 'plain'
+---| 'json'
+
+---@alias box.cfg.wal_mode
+---| 'none' # write-ahead log is not maintained. A node with box.cfg.wal_mode = none can’t be replication master
+---| 'write' # fibers wait for their data to be written to the write-ahead log (no fsync(2))
+---| 'fsync' # fibers wait for their data, fsync(2) follows each write(2)
+
+---# Builtin `box.cfg` submodule
+---
+---The `box.cfg` submodule is used for specifying [server configuration parameters](lua://box.cfg).
+---
+---To view the current configuration, say `box.cfg` without braces.
+---
+--- ```tarantoolsession
+--- tarantool> box.cfg
+--- ---
+--- - checkpoint_count: 2
+---   too_long_threshold: 0.5
+---   slab_alloc_factor: 1.05
+---   memtx_max_tuple_size: 1048576
+---   background: false
+---   <...>
+--- ...
+--- ```
+---
+---To set particular parameters, use the following syntax: `box.cfg{key = value [, key = value ...]}` (further referred to as `box.cfg{...}` for short). For example:
+---
+--- ```tarantoolsession
+--- tarantool> box.cfg{listen = 3301}
+--- ```
+---
+---Parameters that are not specified in the `box.cfg{...}` call explicitly will be set to the [default values](doc://box_cfg_default).
+---
+---The first call to `box.cfg{...}` (with or without parameters) initiates Tarantool's database module [`box`](lua://box).
+---
+---`box.cfg{...}` is also the command that reloads [persistent data files](doc://index-box_persistence) into RAM upon restart once we have data.
+---
+---@class box.cfg: table
+---@field background? boolean (default: false)
+---@field checkpoint_count? number (Default: 2) The maximum number of snapshots that may exist on the memtx_dir directory before the checkpoint daemon will delete old snapshots
+---@field checkpoint_interval? number (Default: 3600 (one hour)) The interval between actions by the checkpoint daemon, in seconds. If checkpoint_interval is set to a value greater than zero, and there is activity which causes change to a database, then the checkpoint daemon will call box.snapshot() every checkpoint_interval seconds, creating a new snapshot file each time. If checkpoint_interval is set to zero, then the checkpoint daemon is disabled
+---@field checkpoint_wal_threshold? number (Default: 10^18 (a large number so in effect there is no limit by default)) The threshold for the total size in bytes of all WAL files created since the last checkpoint
+---@field coredump? boolean (Default: false) DEPRECATED, DO NOT USE
+---@field custom_proc_title? string (Default: nil) Add the given string to the server’s process title
+---@field box.cfg.election_mode? box.cfg.election_mode (Default: off) enables RAFT
+---@field feedback_enabled? boolean (Default: true) Whether to send feedback
+---@field feedback_host? string (Default: 'https://feedback.tarantool.io') The address to which the packet is sent. Usually the recipient is Tarantool, but it can be any URL
+---@field feedback_interval? number (Default: 3600) The number of seconds between sendings, usually 3600 (1 hour).
+---@field force_recovery? boolean (Default: false) If force_recovery equals true, Tarantool tries to continue if there is an error while reading a snapshot file (at server instance start) or a write-ahead log file (at server instance start or when applying an update at a replica): skips invalid records, reads as much data as possible and lets the process finish with a warning. Users can prevent the error from recurring by writing to the database and executing box.snapshot()
+---@field hot_standby? boolean (Default: false) Whether to start the server in hot standby mode. Hot standby is a feature which provides a simple form of failover without replication
+---@field instance_uuid? string (Generated automatically) For replication administration purposes, it is possible to set the universally unique identifiers of the instance (instance_uuid) and the replica set (replicaset_uuid), instead of having the system generate the values
+---@field io_collect_interval? number (Default: nil) The instance will sleep for io_collect_interval seconds between iterations of the event loop. Can be used to reduce CPU load in deployments in which the number of client connections is large, but requests are not so frequent (for example, each connection issues just a handful of requests per second)
+---@field iproto_threads? number (Default: 1) The number of network threads
+---@field listen? string|number (Default: nil) URI to bind tarantool
+---@field log? box.cfg.log (Default: nil) By default, Tarantool sends the log to the standard error stream (stderr). If log is specified, Tarantool sends the log to a file, or to a pipe, or to the system logger.
+---@field box.cfg.log_format? box.cfg.log_format (Default: 'plain')
+---@field box.cfg.log_level? box.cfg.log_level (Default: 5) What level of detail the log will have
+---@field log_nonblock? boolean (Default: true) If log_nonblock equals true, Tarantool does not block during logging when the system is not ready for writing, and drops the message instead
+---@field memtx_dir? string (Default: '.') path to dir with memtx snapshots
+---@field memtx_max_tuple_size? number (Default: 1024 * 1024) Size of the largest allocation unit, for the memtx storage engine. It can be increased if it is necessary to store large tuples
+---@field memtx_memory? number (Default: 256 * 1024 *1024) How much memory Tarantool allocates to actually store tuples
+---@field memtx_min_tuple_size? number (Default: 16) Size of the smallest allocation unit. It can be decreased if most of the tuples are very small
+---@field memtx_use_mvcc_engine? boolean (Default: false) Since version 2.6.1. Enables transactional manager if set to true.
+---@field net_msg_max? number (Default: 768) To handle messages, Tarantool allocates fibers. To prevent fiber overhead from affecting the whole system, Tarantool restricts how many messages the fibers handle, so that some pending requests are blocked
+---@field pid_file? string (Default: nil) Store the process id in this file
+---@field readahead? number (Default: 16320) The size of the read-ahead buffer associated with a client connection
+---@field read_only? boolean (Default: false) should this instance be RO
+---@field replicaset_uuid? string (Generated automatically)
+---@field replication? string[] (Default: nil) list of URI of replicas to connect to
+---@field replication_anon? boolean (Default: false) A Tarantool replica can be anonymous. This type of replica is read-only (but you still can write to temporary and replica-local spaces), and it isn’t present in the _cluster table
+---@field replication_connect_quorum? number (Default: _cluster:len()) required number of connected replicas to start bootstrap
+---@field replication_connect_timeout? number (Default: 30) timeout in seconds to expect replicas in replication to fail bootstrap
+---@field replication_synchro_quorum? string|number (Default: N / 2 + 1. Before version 2.10.0, the default value was 1) number or formula of synchro quorum
+---@field replication_skip_conflict? boolean (Default: false) By default, if a replica adds a unique key that another replica has added, replication stops with error = ER_TUPLE_FOUND
+---@field replication_sync_lag? number (Default: 10) The maximum lag allowed for a replica
+---@field replication_sync_timeout? number (Default: 300) The number of seconds that a replica will wait when trying to sync with a master in a cluster, or a quorum of masters, after connecting or during configuration update
+---@field replication_timeout? number (Defailt: 1) If the master has no updates to send to the replicas, it sends heartbeat messages every replication_timeout seconds, and each replica sends an ACK packet back. Both master and replicas are programmed to drop the connection if they get no response in four replication_timeout periods. If the connection is dropped, a replica tries to reconnect to the master
+---@field slab_alloc_factor? number (Default: 1.05) The multiplier for computing the sizes of memory chunks that tuples are stored in. A lower value may result in less wasted memory depending on the total amount of memory available and the distribution of item sizes. Allowed values range from 1 to 2
+---@field snap_io_rate_limit? number (Default: nil) Reduce the throttling effect of box.snapshot() on INSERT/UPDATE/DELETE performance by setting a limit on how many megabytes per second it can write to disk. The same can be achieved by splitting wal_dir and memtx_dir locations and moving snapshots to a separate disk
+---@field sql_cache_size? number (Default: 5242880) The maximum number of bytes in the cache for SQL prepared statements
+---@field strip_core? boolean (Default: true) Whether coredump files should include memory allocated for tuples
+---@field too_long_threshold? number (Default: 0.5) If processing a request takes longer than the given value (in seconds), warn about it in the log. Has effect only if log_level is more than or equal to 4 (WARNING)
+---@field txn_isolation? txn_isolation (Default: best-effort)
+---@field username? string (Default: nil) UNIX user name to switch to after start
+---@field vinyl_bloom_fpr? number (Default: 0.05) Bloom filter false positive rate – the suitable probability of the bloom filter to give a wrong result
+---@field vinyl_cache? number (Default: 128 * 1024 * 1024) The cache size for the vinyl storage engine
+---@field vinyl_dir? string (Default: '.') A directory where vinyl files or subdirectories will be stored. Can be relative to work_dir. If not specified, defaults to work_dir
+---@field vinyl_max_tuple_size? number (Default: 1024 * 1024) Size of the largest allocation unit, for the vinyl storage engine. It can be increased if it is necessary to store large tuples
+---@field vinyl_memory? number (Default: 128 * 1024 * 1024) The maximum number of in-memory bytes that vinyl uses
+---@field vinyl_page_size? number (Default: 8 * 1024) Page size. Page is a read/write unit for vinyl disk operations. The vinyl_page_size setting is a default value for one of the options in the Options for space_object:create_index() chart
+---@field vinyl_range_size? number (Default: nil) The default maximum range size for a vinyl index, in bytes. The maximum range size affects the decision whether to split a range. If vinyl_range_size is not nil and not 0, then it is used as the default value for the range_size option in the Options for space_object:create_index() chart. If vinyl_range_size is nil or 0, and range_size is not specified when the index is created, then Tarantool sets a value later depending on performance considerations. To see the actual value, use index_object:stat().range_size
+---@field vinyl_read_threads? number (Default: 1) The maximum number of read threads that vinyl can use for some concurrent operations, such as I/O and compression
+---@field vinyl_run_count_per_level? number (Default: 2) The maximal number of runs per level in vinyl LSM tree. If this number is exceeded, a new level is created. The vinyl_run_count_per_level setting is a default value for one of the options in the Options for space_object:create_index() chart
+---@field vinyl_run_size_ratio? number (Default: 3.5) Ratio between the sizes of different levels in the LSM tree. The vinyl_run_size_ratio setting is a default value for one of the options in the Options for space_object:create_index() chart
+---@field vinyl_timeout? number (Default: 60) The vinyl storage engine has a scheduler which does compaction. When vinyl is low on available memory, the compaction scheduler may be unable to keep up with incoming update requests. In that situation, queries may time out after vinyl_timeout seconds. This should rarely occur, since normally vinyl would throttle inserts when it is running low on compaction bandwidth. Compaction can also be ordered manually with index_object:compact()
+---@field vinyl_write_threads? number (Default: 4) The maximum number of write threads that vinyl can use for some concurrent operations, such as I/O and compression
+---@field wal_cleanup_delay? number (Default: 14400 seconds) The delay (in seconds) used to prevent the Tarantool garbage collector from immediately removing write-ahead log files after a node restart.
+---@field wal_dir? string (Default: '.') path to dir with xlogs
+---@field wal_dir_rescan_delay? number (Default: 2) Number of seconds between periodic scans of the write-ahead-log file directory, when checking for changes to write-ahead-log files for the sake of replication or hot standby
+---@field wal_max_size? number (Default: 256 * 1024 * 1024) The maximum number of bytes in a single write-ahead log file. When a request would cause an .xlog file to become larger than wal_max_size, Tarantool creates another WAL file
+---@field box.cfg.wal_mode? box.cfg.wal_mode (Default: 'write') Specify fiber-WAL-disk synchronization mode as
+---@field worker_pool_threads? number (Default: 4) he maximum number of threads to use during execution of certain internal processes (currently socket.getaddrinfo() and coio_call())
+---@field work_dir? string (Default: nil) path to work dir of tarantool
+---@overload fun(box_cfg: box.cfg)
+box.cfg = {}

--- a/tarantool-annotations/Library/box/ctl.lua
+++ b/tarantool-annotations/Library/box/ctl.lua
@@ -1,0 +1,102 @@
+---@meta
+
+---# Builtin `box.ctl` submodule
+---
+---The `wait_ro` (wait until read-only) and `wait_rw` (wait until read-write) functions are useful during server initialization.
+---
+---To see whether a function is already in read-only or read-write mode, check :ref:`box.info.ro <box_introspection-box_info>`.
+---
+---A particular use is for :doc:`box.once() </reference/reference_lua/box_once>`.
+---
+---For example, when a replica is initializing, it may call a `box.once()` function while the server is still in read-only mode, and fail to make changes that are necessary only once before the replica is fully initialized.
+---
+---This could cause conflicts between a master and a replica if the master is in read-write mode and the replica is in read-only mode. Waiting until "read only mode = false" solves this problem.
+box.ctl = {}
+
+---Wait, then choose new replication leader.
+---
+---*Since 2.6.2*
+---*Renamed in 2.6.3*
+---
+---For [synchronous transactions](doc://repl_sync) it is possible that a new leader will be chosen but the transactions of the old leader have not been completed. Therefore to finalize the transaction, the function `box.ctl.promote()` should be called, as mentioned in the notes for
+---[leader election](doc://repl_leader_elect_important).
+---
+---The old name for this function is `box.ctl.clear_synchro_queue()`.
+---
+---The [election state](lua://box.info.election) should change to `leader`.
+function box.ctl.promote() end
+
+---Revoke the leader role from the instance.
+---
+---*Since 2.10.0*
+---
+---On [synchronous transaction queue owner](lua://box.info.synchro), the function works in the following way:
+---* If [`box.cfg.election_mode`](doc://cfg_replication-election_mode) is `off`, the function writes a `DEMOTE` request to WAL. The `DEMOTE` request clears the ownership of the synchronous transaction queue, while the `PROMOTE` request assigns it to a new instance.
+---* If [`box.cfg.election_mode`](doc://cfg_replication-election_mode) is enabled in any mode, then the function makes the instance start a new term and give up the leader role.
+---
+---On instances that are not queue owners, the function does nothing and returns immediately.
+function box.ctl.demote() end
+
+---Wait until `box.info.ro` is false.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> n = box.ctl.wait_ro(0.1)
+--- ---
+--- ...
+--- ```
+---
+---@async
+---@param timeout? number
+function box.ctl.wait_rw(timeout) end
+
+---Wait until `box.info.ro` is true.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> box.info().ro
+--- ---
+--- - false
+--- ...
+---
+--- tarantool> n = box.ctl.wait_ro(0.1)
+--- ---
+--- - error: timed out
+--- ...
+--- ```
+---
+---@async
+---@param timeout? number
+function box.ctl.wait_ro(timeout) end
+
+---Create a shutdown trigger.
+---
+---The `trigger-function` will be executed whenever [`os.exit()`](os.exit) happens, or when the server is shut down after receiving a `SIGTERM` or `SIGINT` or `SIGHUP` signal (but not after `SIGSEGV` or `SIGABORT` or any signal that causes immediate program termination).
+---
+---If the parameters are (nil, old-trigger-function), then the old trigger is deleted.
+---
+---If you want to set a timeout for this trigger, use the [`set_on_shutdown_timeout`](lua://box.ctl.on_shutdown_timeout) function.
+---
+---@param trigger_function fun()
+---@param old_trigger_function? fun()
+---@return fun()? created_trigger
+function box.ctl.on_shutdown(trigger_function, old_trigger_function) end
+
+---Create a trigger executed when leader election changes replica state.
+---
+---* Since 2.10.0 *
+---
+---Create a [trigger](doc://triggers) executed every time the current state of a replica set node in regard to [leader election](doc://repl_leader_elect) changes.
+---
+---The current state is available in the [`box.info.election`](lua://box.info.election) table.
+---
+---The trigger doesn't accept any parameters.
+---
+---You can see the changes in `box.info.election` and [`box.info.synchro`](box.info.synchro).
+---
+---@param trigger function
+function box.ctl.on_election(trigger) end
+
+return box.ctl

--- a/tarantool-annotations/Library/box/error.lua
+++ b/tarantool-annotations/Library/box/error.lua
@@ -1,0 +1,136 @@
+---@meta
+
+---@class box.error: ffi.cdata*
+---@field type string The error type (usually ClientError).
+---@field base_type string The base type (usually ClientError).
+---@field code number Number of error.
+---@field prev? box.error *Since 2.4.1* The previous error for the current one.
+---@field message any The error message.
+---@field reason string *Since 2.10.0* Returns the `box.info.ro_reason` value at the moment of throwing the `box.error.READONLY` error.
+---@field errno? number If the error is a system error (for example, a socket or file IO failure), a C standard error number.
+---@field state? string For the box.error.READONLY error, returns the current state of a replica set node in regards to leader election (see [`box.info.election.state`](lua://box.info.election.state)).
+local box_error_object = {}
+
+---# Builtin `box.error` submodule.
+---
+---The `box.error` submodule can be used to work with errors in your application.
+---
+---For example, you can get the information about the last error raised by Tarantool or raise custom errors manually.
+---
+---The difference between raising an error using `box.error` and a Lua's built-in [error](https://www.lua.org/pil/8.3.html) function is that when the error reaches the client, its error code is preserved.
+---
+---In contrast, a Lua error would always be presented to the client as `ER_PROC_LUA`.
+---
+---**Note:**
+---
+---To learn how to handle errors in your application, see the [handling errors](doc://error_handling) section.
+---
+---When called without arguments, box.error() re-throws whatever the last error was.
+---@overload fun(): box.error
+box.error = {}
+
+---Throw an error. When called with a Lua-table argument, the code and reason have any user-desired values. The result will be those values.
+---
+---@param err { reason: string, code: number? } reason is description of an error, defined by user; code is numeric code for this error, defined by user
+---@return box.error
+function box.error(err) end
+
+---Throw an error. This method emulates a request error, with text based on one of the pre-defined Tarantool errors defined in the file errcode.h in the source tree.
+---@param code number number of a pre-defined error
+---@param errtext string part of the message which will accompany the error
+---@param ... string part of the message which will accompany the error
+function box.error(code, errtext, ...) end
+
+---@class box.error.trace
+---@field file string Tarantool source file
+---@field line number Tarantool source file line number
+
+---@class box.error.table
+---@field code number error's number
+---@field type string error's C++ class
+---@field message string error's message
+---@field prev? box.error previous error
+---@field base_type string usually ClientError or CustomError
+---@field custom_type string? present if custom ErrorType was passed
+---@field trace box.error.trace[]? backtrace
+
+---Get error details that may include an error code, type, message, and trace.
+---
+---@return box.error.table
+function box_error_object:unpack() end
+
+---Raise the current error.
+function box_error_object:raise() end
+
+---Create an error object with the specified parameters.
+---
+---**Examples:**
+---
+--- ```lua
+--- local custom_error = box.error.new({ code = 500,
+---                                      reason = 'Internal server error' })
+---
+--- box.error(custom_error)
+--- --[[
+--- ---
+--- - error: Internal server error
+--- ...
+--- --]]
+--- ```
+---
+--- ```lua
+--- local custom_error = box.error.new({ code = 500,
+---                                      reason = 'Internal server error',
+---                                      type = 'CustomInternalError' })
+---
+--- box.error(custom_error)
+--- --[[
+--- ---
+--- - error: Internal server error
+--- ...
+--- --]]
+--- ```
+---
+--- ```lua
+--- local custom_error = box.error.new('CustomInternalError', 'Internal server error')
+---
+--- box.error(custom_error)
+--- --[[
+--- ---
+--- - error: Internal server error
+--- ...
+--- --]]
+--- ```
+---
+--- ```lua
+--- local custom_error = box.error.new(box.error.NO_SUCH_USER, 'John')
+---
+--- box.error(custom_error)
+--- --[[
+--- ---
+--- - error: User 'John' is not found
+--- ...
+--- --]]
+--- ```
+---
+--- ```lua
+--- local custom_error = box.error.new(box.error.CREATE_SPACE, 'my_space', 'the space already exists')
+---
+--- box.error(custom_error)
+--- --[[
+--- ---
+--- - error: 'Failed to create space ''my_space'': the space already exists'
+--- ...
+--- --]]
+--- ```
+---
+---@param err { reason: string, code: number?, type: string? } custom error
+---@return box.error
+---@overload fun(code: number, errtxt: string): box.error
+---@overload fun(type: string, reason: string, ...): box.error
+function box.error.new(err) end
+
+---Get the last error that was raised.
+---
+---@return box.error
+function box.error.last() end

--- a/tarantool-annotations/Library/box/index.lua
+++ b/tarantool-annotations/Library/box/index.lua
@@ -1,0 +1,452 @@
+---@meta
+
+----@alias box.index_part_def {[2]: tuple_type_name | nil, type?: tuple_type_name, is_nullable?: boolean, collation?: string, path: string, fieldno?: integer } & ({ field: integer | string } | { [1]: integer | string })
+---@alias box.index_part_def {[2]: tuple_type_name | nil, type?: tuple_type_name, is_nullable?: boolean, collation?: string, path: string, fieldno?: integer, field: integer | string }
+
+---@alias box.index_type "TREE" | "HASH" | "BITSET" | "RTREE" | "tree" | "hash" | "bitset" | "rtree"
+
+---@class box.index_options: table
+---@field name? string name of the index
+---@field type? box.index_type (Default: "TREE") type of index
+---@field id? integer (Default: last index’s id + 1) unique identifier
+---@field unique? boolean (Default: true) index is unique
+---@field if_not_exists? boolean (Default: false) no error if duplicate name
+---@field parts? box.index_part_def[] | string[] field numbers + types
+---@field dimension? integer (Default: 2) affects RTREE only
+---@field distance? "euclid" | "manhattan" (Default: euclid) affects RTREE only
+---@field bloom_fpr? number (Default: vinyl_bloom_fpr) affects vinyl only
+---@field page_size? number (Default: vinyl_page_size) affects vinyl only
+---@field range_size? number (Default: vinyl_range_size) affects vinyl only
+---@field run_count_per_level? number (Default: vinyl_run_count_per_level) affects vinyl only
+---@field run_size_ratio? number (Default: vinyl_run_size_ratio) affects vinyl only
+---@field sequence? string|number
+---@field func? string functional index
+---@field hint? boolean (Default: true) affects TREE only. true makes an index work faster, false – index size is reduced by half
+
+---@class box.index_part
+---@field type string type of the field
+---@field is_nullable boolean false if field not-nullable, otherwise true
+---@field fieldno integer position in tuple of the field
+
+---@class box.index<T, U>: box.index_options
+---@field parts box.index_part[] list of index parts
+local index_methods = {}
+
+---Search for a tuple via the given index.
+---
+---**Possible errors:**
+---
+---* `index_object` does not exist.
+---* Wrong type.
+---* More than one tuple matches.
+---
+---**Complexity factors:**
+---
+---* Index size.
+---* Index type.
+---
+---The `box.space...select` function returns a set of tuples as a Lua table; the `box.space...get` function returns at most a single tuple.
+---And it is possible to get the first tuple in a space by appending `[1]`. Therefore `box.space.tester:get{1}` has the same effect as `box.space.tester:select{1}[1]`, if exactly one tuple is found.
+---
+---**Example:**
+---
+--- ```
+--- ```tarantoolsession
+--- tarantool> box.space.tester.index.primary:get(2)
+--- ---
+--- - [2, 'Music']
+--- ...
+--- ```
+---
+---@param key box.tuple<T, U>|tuple_type[]|scalar
+---@return box.tuple<T, U>? tuple the tuple whose index key matches key, or nil.
+function index_methods:get(key) end
+
+---Search for a tuple or a set of tuples by the current index.
+---
+---To search by the primary index in the specified space, use the [`box.space.select`](lua://box.space.select) method.
+---
+---**Note:** this method doesn't yield. For details, [Cooperative multitasking](doc://app-cooperative_multitasking).
+---
+---**Note:** the `after` and `fetch_pos` options are supported for the `TREE` :ref:`index <index-types>` only.
+---
+---This function might return one or two values:
+---* The tuples whose fields are equal to the fields of the passed key. If the number of passed fields is less than the number of fields in the current key, then only the passed fields are compared, so `select{1,2}` matches a tuple whose primary key is `{1,2,3}`.
+---* (Optionally) If `options.fetch_pos` is set to `true`, returns a base64-encoded string representing the position of the last selected tuple as the second value.
+---
+---If no tuples are fetched, returns `nil`.
+---
+---**Warning:**
+---
+---Use the `offset` option carefully when scanning large data sets as it linearly increases the number of scanned tuples and leads to a full space scan. Instead, you can use the `after` and `fetch_pos` options.
+---
+---**Examples:**
+---
+--- ```lua
+--- box.space.bands:insert { 1, 'Roxette', 1986 }
+--- box.space.bands:insert { 2, 'Scorpions', 1965 }
+--- box.space.bands:insert { 3, 'Ace of Base', 1987 }
+--- box.space.bands:insert { 4, 'The Beatles', 1960 }
+--- box.space.bands:insert { 5, 'Pink Floyd', 1965 }
+--- box.space.bands:insert { 6, 'The Rolling Stones', 1962 }
+--- box.space.bands:insert { 7, 'The Doors', 1965 }
+--- box.space.bands:insert { 8, 'Nirvana', 1987 }
+--- box.space.bands:insert { 9, 'Led Zeppelin', 1968 }
+--- box.space.bands:insert { 10, 'Queen', 1970 }
+---
+--- -- Select a tuple by the specified primary key value --
+--- select_primary = bands.index.primary:select { 1 }
+--- --[[
+--- ---
+--- - - [1, 'Roxette', 1986]
+--- ...
+--- --]]
+---
+--- -- Select a tuple by the specified secondary key value --
+--- select_secondary = bands.index.band:select { 'The Doors' }
+--- --[[
+--- ---
+--- - - [7, 'The Doors', 1965]
+--- ...
+--- --]]
+---
+--- -- Select a tuple by the specified multi-part secondary key value --
+--- select_multipart = bands.index.year_band:select { 1960, 'The Beatles' }
+--- --[[
+--- ---
+--- - - [4, 'The Beatles', 1960]
+--- ...
+--- --]]
+---
+--- -- Select tuples by the specified partial key value --
+--- select_multipart_partial = bands.index.year_band:select { 1965 }
+--- --[[
+--- ---
+--- - - [5, 'Pink Floyd', 1965]
+---   - [2, 'Scorpions', 1965]
+---   - [7, 'The Doors', 1965]
+--- ...
+--- --]]
+---
+--- -- Select maximum 3 tuples by the specified secondary index --
+--- select_limit = bands.index.band:select({}, { limit = 3 })
+--- --[[
+--- ---
+--- - - [3, 'Ace of Base', 1987]
+---   - [9, 'Led Zeppelin', 1968]
+---   - [8, 'Nirvana', 1987]
+--- ...
+--- --]]
+---
+--- -- Select maximum 3 tuples with the key value greater than 1965 --
+--- select_greater = bands.index.year:select({ 1965 }, { iterator = 'GT', limit = 3 })
+--- --[[
+--- ---
+--- - - [9, 'Led Zeppelin', 1968]
+---   - [10, 'Queen', 1970]
+---   - [1, 'Roxette', 1986]
+--- ...
+--- --]]
+---
+--- -- Select maximum 3 tuples after the specified tuple --
+--- select_after_tuple = bands.index.primary:select({}, { after = { 4, 'The Beatles', 1960 }, limit = 3 })
+--- --[[
+--- ---
+--- - - [5, 'Pink Floyd', 1965]
+---   - [6, 'The Rolling Stones', 1962]
+---   - [7, 'The Doors', 1965]
+--- ...
+--- --]]
+---
+--- -- Select first 3 tuples and fetch a last tuple's position --
+--- result, position = bands.index.primary:select({}, { limit = 3, fetch_pos = true })
+--- -- Then, pass this position as the 'after' parameter --
+--- select_after_position = bands.index.primary:select({}, { limit = 3, after = position })
+--- --[[
+--- ---
+--- - - [4, 'The Beatles', 1960]
+---   - [5, 'Pink Floyd', 1965]
+---   - [6, 'The Rolling Stones', 1962]
+--- ...
+--- --]]
+---```
+---
+---**Note:**
+---
+---`box.space.{space-name}.index.{index-name}:select(...)[1]` can be replaced with `box.space.{space-name}.index.{index-name}:get(...)`.
+---
+---That is, `get` can be used as a convenient shorthand to get the first tuple in the tuple set that would be returned by `select`.
+---
+---However, if there is more than one tuple in the tuple set, then `get` throws an error.
+---
+---@param key box.tuple<T, U> | tuple_type[] | scalar
+---@param options? box.space.select_options
+---@return box.tuple<T, U>[] list the list of tuples
+function index_methods:select(key, options) end
+
+---Search for a tuple or a set of tuples via the given index, and allow iterating over one tuple at a time.
+---
+---To search by the primary index in the specified space, use the [`box.space.pairs`](lua://box.space.pairs) method.
+---
+---The `{key}` parameter specifies what must match within the index.
+---
+---**Note:** `{key}` is only used to find the first match. Do not assume all matched tuples will contain the key.
+---
+---The `{iterator}` parameter specifies the rule for matching and ordering. Different index types support different iterators. For example, a TREE index maintains a strict order of keys and can return all tuples in ascending or descending order, starting from the specified key. Other index types, however, do not support ordering.
+---
+---To understand consistency of tuples returned by an iterator, it's essential to know the principles of the Tarantool transaction processing subsystem. An iterator in Tarantool does not own a consistent read view.
+---
+---Instead, each procedure is granted exclusive access to all tuples and spaces until there is a "context switch": which may happen due to [the implicit yield rules](doc://app-implicit-yields), or by an explicit call to [`fiber.yield`](lua://fiber-yield).
+---
+---When the execution flow returns to the yielded procedure, the data set could have changed significantly. Iteration, resumed after a yield point, does not preserve the read view, but continues with the new content of the database. The tutorial [indexed pattern search](doc://c_lua_tutorial-indexed_pattern_search) shows one way that iterators and yields can be used together.
+---
+---For information about iterators' internal structures, see the ["Lua Functional library"](https://luafun.github.io/index.html) documentation.
+---
+---**Examples:**
+---
+--- ```tarantoolsession
+--- -- Insert test data --
+--- tarantool> bands:insert{1, 'Roxette', 1986}
+--- bands:insert{2, 'Scorpions', 1965}
+--- bands:insert{3, 'Ace of Base', 1987}
+--- bands:insert{4, 'The Beatles', 1960}
+--- bands:insert{5, 'Pink Floyd', 1965}
+--- bands:insert{6, 'The Rolling Stones', 1962}
+--- bands:insert{7, 'The Doors', 1965}
+--- bands:insert{8, 'Nirvana', 1987}
+--- bands:insert{9, 'Led Zeppelin', 1968}
+--- bands:insert{10, 'Queen', 1970}
+--- ---
+--- ...
+---
+--- -- Select all tuples by the primary index --
+--- tarantool> for _, tuple in bands.index.primary:pairs() do
+--- print(tuple)
+--- end
+--- [1, 'Roxette', 1986]
+--- [2, 'Scorpions', 1965]
+--- [3, 'Ace of Base', 1987]
+--- [4, 'The Beatles', 1960]
+--- [5, 'Pink Floyd', 1965]
+--- [6, 'The Rolling Stones', 1962]
+--- [7, 'The Doors', 1965]
+--- [8, 'Nirvana', 1987]
+--- [9, 'Led Zeppelin', 1968]
+--- [10, 'Queen', 1970]
+--- ---
+--- ...
+---
+--- -- Select all tuples whose secondary key values start with the specified string --
+--- tarantool> for _, tuple in bands.index.band:pairs("The", {iterator = "GE"}) do
+--- if (string.sub(tuple[2], 1, 3) ~= "The") then break end
+--- print(tuple)
+--- end
+--- [4, 'The Beatles', 1960]
+--- [7, 'The Doors', 1965]
+--- [6, 'The Rolling Stones', 1962]
+--- ---
+--- ...
+---
+--- -- Select all tuples whose secondary key values are between 1965 and 1970 --
+--- tarantool> for _, tuple in bands.index.year:pairs(1965, {iterator = "GE"}) do
+--- if (tuple[3] > 1970) then break end
+--- print(tuple)
+--- end
+--- [2, 'Scorpions', 1965]
+--- [5, 'Pink Floyd', 1965]
+--- [7, 'The Doors', 1965]
+--- [9, 'Led Zeppelin', 1968]
+--- [10, 'Queen', 1970]
+--- ---
+--- ...
+---
+--- -- Select all tuples after the specified tuple --
+--- tarantool> for _, tuple in bands.index.primary:pairs({}, {after={7, 'The Doors', 1965}}) do
+--- print(tuple)
+--- end
+--- [8, 'Nirvana', 1987]
+--- [9, 'Led Zeppelin', 1968]
+--- [10, 'Queen', 1970]
+--- ---
+--- ...
+--- ```
+---
+---@param key box.tuple<T, U> | tuple_type[] | scalar value to be matched against the index key, which may be multi-part
+---@param iterator? box.iterator (Default: 'EQ') defines iterator order
+---@return box.space.iterator<T, U> iter Luafun iterator
+---@return box.space.iterator.param
+---@return box.space.iterator.state
+function index_methods:pairs(key, iterator) end
+
+---Update a tuple.
+---
+---The update function supports operations on fields — assignment, arithmetic (if the field is numeric), cutting and pasting fragments of a field, deleting or inserting a field.
+---Multiple operations can be combined in a single update request, and in this case they are performed atomically and sequentially.
+---Each operation requires specification of a field identifier, which is usually a number.
+---When multiple operations are present, the field number for each operation is assumed to be relative to the most recent state of the tuple, that is, as if all previous operations in a multi-operation update have already been applied.
+---In other words, it is always safe to merge multiple update invocations into a single invocation, with no change in semantics.
+---@param key box.tuple<T,U> | tuple_type[] | scalar
+---@param update_operations [box.update_operation, number|string, tuple_type][]
+---@return box.tuple<T,U>? tuple the updated tuple if it was found
+function index_methods:update(key, update_operations) end
+
+---Find the maximum value in the specified index.
+---
+---**Possible errors:**
+---
+---* Index is not of type 'TREE'.
+---* `ER_TRANSACTION_CONFLICT` if a transaction conflict is detected in the [`MVCC transaction mode`](doc://txn_mode_transaction-manager).
+---
+---**Complexity factors:**
+---* Index size.
+---* Index type.
+---
+---**Examples:**
+---
+--- ```lua
+--- -- Find the maximum value in the specified index
+--- max = box.space.bands.index.year:max()
+--- --[[
+--- ---
+--- - [8, 'Nirvana', 1987]
+--- ...
+--- --]]
+---
+--- -- Find the maximum value that matches the partial key value
+--- max_partial = box.space.bands.index.year_band:max(1965)
+--- --[[
+--- ---
+--- - [7, 'The Doors', 1965]
+--- ...
+--- --]]
+--- ```
+---
+---@param key box.tuple<T, U> | tuple_type[] | scalar
+---@return box.tuple<T, U>? tuple result
+function index_methods:max(key) end
+
+---Find the minimum value in the specified index.
+---
+---**Possible errors:**
+---
+---* Index is not of type 'TREE'.
+---* `ER_TRANSACTION_CONFLICT` if a transaction conflict is detected in the [`MVCC transaction mode`](doc://txn_mode_transaction-manager).
+---
+---**Complexity factors:**
+---* Index size.
+---* Index type.
+---
+---**Examples:**
+---
+--- ```lua
+--- min = box.space.bands.index.year:min()
+--- --[[
+--- ---
+--- - [4, 'The Beatles', 1960]
+--- ...
+--- --]]
+---
+--- -- Find the minimum value that matches the partial key value
+--- min_partial = box.space.bands.index.year_band:min(1965)
+--- --[[
+--- ---
+--- - [5, 'Pink Floyd', 1965]
+--- ...
+--- --]]
+--- ```
+---
+---@param key box.tuple<T, U> | tuple_type[] | scalar
+---@return box.tuple<T, U>? tuple result
+function index_methods:min(key) end
+
+---Iterate over an index, counting the number of tuples which match the key-value.
+---
+---Return the number of tuples. If compared with `len()`, this method works slower because `count()` scans the entire space to `count` the tuples.
+---
+---**Example:**
+---
+--- ```lua
+--- -- Count the number of tuples that match the full key value
+--- count = box.space.bands.index.year:count(1965)
+--- --[[
+--- ---
+--- - 3
+--- ...
+--- --]]
+---
+--- -- Count the number of tuples that match the partial key value
+--- count_partial = box.space.bands.index.year_band:count(1965)
+--- --[[
+--- ---
+--- - 3
+--- ...
+--- --]]
+--- ```
+---@param key? box.tuple<T, U> | tuple_type[] | scalar
+---@param iterator? box.iterator
+---@return integer number_of_tuples
+function index_methods:count(key, iterator) end
+
+---Return the total number of bytes taken by the index.
+---
+---@return integer
+function index_methods:bsize() end
+
+---Delete a tuple identified by a key.
+---
+---Same as [`box.space...delete()`](box.space.delete), but key is searched in this index instead of in the primary-key index.
+---
+---This index ought to be unique.
+---
+---**Note regarding storage engine:** vinyl will return `nil`, rather than the deleted tuple.
+---
+---@param key box.tuple<T, U> | tuple_type[] | scalar
+---@return box.tuple<T, U>? tuple the deleted tuple
+function index_methods:delete(key) end
+
+---Alter an index.
+---
+---It is legal in some circumstances to change one or more of the index characteristics, for example its type, its sequence options, its parts, and whether it is unique.
+---
+---Usually this causes rebuilding of the space, except for the simple case where a part’s is_nullable flag is changed from false to true.
+---
+---@param opts box.index_options
+function index_methods:alter(opts) end
+
+---Return a tuple's position for an index.
+---
+---This value can be passed to the `after` option of the `select` and `pairs` methods:
+---* [`index_object:select`](lua://box.index.select) and [`space_object:select`](lua://box.space.select)
+---* [`index_object:pairs`](lua://box.index.pairs) and [`space_object:pairs`](lua://box.space.pairs)
+---
+---**Note:** `tuple_pos` does not work with [functional](box.space.index.func) and multikey indexes.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- -- Insert test data --
+--- tarantool> bands:insert{1, 'Roxette', 1986}
+--- bands:insert{2, 'Scorpions', 1965}
+--- bands:insert{3, 'Ace of Base', 1987}
+--- bands:insert{4, 'The Beatles', 1960}
+--- bands:insert{5, 'Pink Floyd', 1965}
+--- bands:insert{6, 'The Rolling Stones', 1962}
+--- ---
+--- ...
+---
+--- -- Get a tuple's position --
+--- tarantool> position = bands.index.primary:tuple_pos({3, 'Ace of Base', 1987})
+--- ---
+--- ...
+--- -- Pass the tuple's position as the 'after' parameter --
+--- tarantool> bands:select({}, {limit = 3, after = position})
+--- ---
+--- - - [4, 'The Beatles', 1960]
+--- - [5, 'Pink Floyd', 1965]
+--- - [6, 'The Rolling Stones', 1962]
+--- ...
+--- ```
+---
+---@param tuple scalar | table
+---@return string # base64-encoded string (a tuple’s position in a space)
+function index_methods:tuple_pos(tuple) end

--- a/tarantool-annotations/Library/box/info.lua
+++ b/tarantool-annotations/Library/box/info.lua
@@ -1,0 +1,103 @@
+---@meta
+
+---@class box.info.election: table
+---@field state "leader" | "follower" | "candidate"
+---@field vote integer ID of a node the current node votes for. If the value is 0, it means the node hasn't voted in the current term yet.
+---@field leader integer Leader node ID in the current term. If the value is 0, it means the node doesn't know which node is the leader in the current term.
+---@field term integer Current election term.
+
+---@class box.info.cluster: table
+---@field uuid string UUID of the replicaset this instance belong.
+
+---@class box.info.synchro.queue: table
+---@field owner number ID of the replica that owns the synchronous transaction queue.
+---@field term number Current queue term. It contains the term of the last PROMOTE request.
+---@field len number The number of entries that are currently waiting in the queue.
+---@field busy boolean The boolean value is true when the instance is processing or writing some system request that modifies the queue (for example, PROMOTE, CONFIRM, or ROLLBACK).
+
+---@class box.info.syncho: table
+---@field quorum number The resulting value of the `replication_synchro_quorum` configuration option.
+---@field queue box.info.synchro.queue
+
+---@class box.info.downstream: table
+---appears (is not nil) with data about an instance that is following instance n or is intending to follow it
+---@field status "follow" | "stopped "
+---@field idle number The time (in seconds) since the last time that instance n sent events through the downstream replication.
+---@field lag number The time difference between the local time at the master node, recorded when a particular transaction was written to the write ahead log, and the local time recorded when it receives an acknowledgement for this transaction from a replica.
+---@field vclock integer[] May be the same as the current instance's vclock.
+---@field message? string
+---@field system_message? string
+
+---@class box.info.upstream: table
+---@field peer string Contains instances URI, for example `127.0.0.1:3302`.
+---@field status "auth" | "connecting" | "disconnecting" | "disconnected" | "follow" | "stopped" | "sync"
+---@field idle number The time (in seconds) since the last event was received. This is the primary indicator of replication health.
+---@field lag number The time difference between the local time of instance n, recorded when the event was received, and the local time at another master recorded when the event was written to the write ahead log on that master.
+---@field message? string Contains an error message in case of a degraded state, otherwise it is `nil`.
+
+---@class box.info.replica: table
+---@field id integer A short numeric identifier of instance n within the replica set.
+---@field uuid string A globally unique identifier of instance n.
+---@field lsn integer A log sequence number (LSN) for the latest entry in instance n's write ahead log (WAL).
+---@field upstream? box.info.upstream
+---@field downstream? box.info.downstream
+
+---# Builtin `box.info` submodule
+---
+---The `box.info` submodule provides access to information about a running Tarantool instance.
+---
+---@class box.info: table
+---@field id integer A short numeric identifier of instance n within the replica set. This value is stored in the box.space._cluster system space.
+---@field uuid string A globally unique identifier of instance n.
+---@field pid integer A process ID.
+---@field uptime integer A number of seconds since the instance started.
+---@field status "unconfigured" | "running" | "loading" | "orphan" | "hot_standby" 
+---@field lsn integer A log sequence number (LSN) for the latest entry in instance n's write ahead log (WAL).
+---@field version string A Tarantool version number.
+---@field ro boolean Is `true` if the instance is in "read-only" mode.
+---@field public package string
+---@field vclock integer[] A table with the vclock values of all instances in a replica set which have made data changes.
+---@field replication table<integer,box.info.replica>
+---@field election box.info.election Shows the current state of a replica set node regarding leader election.
+---@field signature integer The sum of all lsn values from each vector clock (vclock) for all instances in the replica set.
+---@field cluster box.info.cluster
+---@field ro_reason string
+---@field synchro table
+---@overload fun(): box.info
+box.info = {}
+
+---@class box.info.memory
+---@field cache integer A number of bytes used for caching user data. The memtx storage engine does not require a cache, so in fact this is the number of bytes in the cache for the tuples stored for the vinyl storage engine.
+---@field data integer A number of bytes used for storing user data (the tuples) with the memtx engine and with level 0 of the vinyl engine, without taking memory fragmentation into account.
+---@field index integer A number of bytes used for indexing user data, including memtx and vinyl memory tree extents, the vinyl page index, and the vinyl bloom filters.
+---@field lua integer A number of bytes used for Lua runtime.
+---@field net integer A number of bytes used for network input/output buffers.
+---@field tx integer A number of bytes in use by active transactions. For the vinyl storage engine, this is the total size of all allocated objects (struct txv, struct vy_tx, struct vy_read_interval) and tuples pinned for those objects.
+
+---Get information about memory usage for the current instance.
+---
+---**Note:**
+---
+---To get a picture of the vinyl subsystem, use [box.stat.vinyl()](lua://box.stat.vinyl) instead.
+---
+---@return box.info.memory
+function box.info.memory() end
+
+---@class box.info.gc.checkpoint: table
+---@field references table[] A list of references to a checkpoint.
+---@field vclock integer[] A checkpoint's vclock value.
+---@field signature integer A sum of a checkpoint's vclock's components.
+
+---@class box.info.gc: table
+---@field vclock integer[] The garbage collector's vclock.
+---@field signature integer The sum of the garbage collector's checkpoint's components.
+---@field checkpoint_is_in_progress boolean `true` if a checkpoint is in progress, otherwise `false`.
+---@field consumers table[] A list of users whose requests might affect the garbage collector.
+---@field checkpoints box.info.gc.checkpoint[] A list of preserved checkpoints.
+
+---Get information about the [Tarantool garbage collector](doc://configuration_persistence_garbage_collector).
+---
+---The garbage collector compares vclock (see [vector clock](doc://replication-vector)) values of users and checkpoints, so a look at `box.info.gc()` may show why the garbage collector has not removed old WAL files, or show what it may soon remove.
+---
+---@return box.info.gc
+function box.info.gc() end

--- a/tarantool-annotations/Library/box/schema.lua
+++ b/tarantool-annotations/Library/box/schema.lua
@@ -1,0 +1,190 @@
+---@meta
+
+---# Builtin `box.schema` submodule
+---
+---The `box.schema` submodule has data-definition functions for spaces, users, roles, function tuples, and sequences.
+box.schema = {}
+
+box.schema.space = {}
+
+---@class box.schema.create_space_options: table
+---@field engine? "memtx" | "vinyl" (Default: "memtx") `memtx` keeps all data in random-access memory (RAM), and therefore has a low read latency.
+---@field field_count? number fixed count of fields: for example if field_count=5, it is illegal to insert a tuple with fewer than or more than 5 fields
+---@field format? box.space.format
+---@field id? number (Default: last space's id, +1) unique identifier: users can refer to spaces with the id instead of the name
+---@field if_not_exists? boolean (Default: false) create space only if a space with the same name does not exist already, otherwise do nothing but do not cause an error
+---@field is_local? boolean (Default: false) space contents are replication-local: changes are stored in the write-ahead log of the local node but there is no replication.
+---@field is_sync? boolean (Default: false) any transaction doing a DML request on this space becomes synchronous
+---@field temporary? boolean (Default: false) space contents are temporary: changes are not stored in the write-ahead log and there is no replication. Note regarding storage engine: vinyl does not support temporary spaces.
+---@field user? string (Default: current user's name) name of the user who is considered to be the space's owner for authorization purposes
+
+---Create a [space](lua://box.space).
+---
+---You can use either syntax. For example, `s = box.schema.space.create('tester')` has the same effect as `s = box.schema.create_space('tester')`.
+---
+---There are [three syntax variations](doc://app_server-object_reference) for object references targeting space objects, for example `box.schema.space.drop({space-id})` drops a space.
+---
+---However, the common approach is to use functions attached to the space objects, for example [`space_object:drop()`](lua://box.space.drop).
+---
+---After a space is created, usually the next step is to [create an index](lua://box.space.create_index) for it, and then it is available for insert, select, and all the other [`box.space`](box_space) functions.
+---
+---@see box.schema.create_space
+---
+---@generic T, U
+---@param space_name string
+---@param options? box.schema.create_space_options
+---@return box.space<T, U>
+function box.schema.space.create(space_name, options) end
+
+---Create a [space](lua://box.space).
+---
+---You can use either syntax. For example, `s = box.schema.space.create('tester')` has the same effect as `s = box.schema.create_space('tester')`.
+---
+---There are [three syntax variations](doc://app_server-object_reference) for object references targeting space objects, for example `box.schema.space.drop({space-id})` drops a space.
+---
+---However, the common approach is to use functions attached to the space objects, for example [`space_object:drop()`](lua://box.space.drop).
+---
+---After a space is created, usually the next step is to [create an index](lua://box.space.create_index) for it, and then it is available for insert, select, and all the other [`box.space`](box_space) functions.
+---
+---@see box.schema.space.create
+---
+---@generic T, U
+---@param space_name string
+---@param options? box.schema.create_space_options
+---@return box.space<T, U>
+function box.schema.create_space(space_name, options) end
+
+---Upgrade the schema to the current version.
+---
+---If you created a database with an older Tarantool version and have now installed a newer version, make the request `box.schema.upgrade()`. This updates
+---
+---Tarantool system spaces to match the currently installed version of Tarantool. You can learn about the general upgrade process from the [upgrades](doc://admin-upgrades) topic.
+---
+---**Example:** here is what happens when you run `box.schema.upgrade()` with a database created with Tarantool version 1.6.4 to version 1.7.2 (only a small part of the output is shown):
+---
+--- ```tarantoolsession
+--- tarantool> box.schema.upgrade()
+--- alter index primary on _space set options to {"unique":true}, parts to [[0,"unsigned"]]
+--- alter space _schema set options to {}
+--- create view _vindex...
+--- grant read access to 'public' role for _vindex view
+--- set schema version to 1.7.0
+--- ---
+--- ...
+--- ```
+---
+---You can also put the request `box.schema.upgrade()` inside a [`box.once()`](doc://box.once) function in your Tarantool [initialization file](doc://index-init_label).
+---
+---On startup, this will create new system spaces, update data type names (for example, `num` -> `unsigned`, `str` -> `string`) and options in Tarantool system spaces.
+---
+---@see box.schema.downgrade
+function box.schema.upgrade() end
+
+---Downgrade the schema to the specified version.
+---
+---Allows you to downgrade a database to the specified Tarantool version.
+---
+---This might be useful if you need to run a database on older Tarantool versions.
+---
+---To prepare a database for using it on an older Tarantool instance, call `box.schema.downgrade` and pass the desired Tarantool version:
+---
+--- ```tarantoolsession
+--- tarantool> box.schema.downgrade('2.8.4')
+--- ```
+---
+---**Note:**
+---
+---The Tarantool's downgrade procedure is similar to the upgrade process that is described in the [upgrades](doc://admin-upgrades) topic.
+---
+---You need to run `box.schema.downgrade()` only on master and execute `box.snapshot()` on every instance in a replica set before restart to an older version.
+---
+---To see Tarantool versions available for downgrade, call [`box.schema.downgrade_versions()`](lua://<box.schema.downgrade_versions). The oldest release available for downgrade is `2.8.2`.
+---
+---Note that the downgrade process might fail if the database enables specific features not supported in the target Tarantool version.
+---
+---You can see all such issues using the [`box.schema.downgrade_issues()`](lua://box.schema.downgrade_issues) method, which accepts the target version.
+---
+---**Example:** `downgrade` to the `2.8.4` version fails if you use [tuple compression](doc://tuple_compression) or field [constraints](doc://constraint_functions) in your database:
+---
+--- ```tarantoolsession
+--- tarantool> box.schema.downgrade_issues('2.8.4')
+--- ---
+--- - - Tuple compression is found in space 'bands', field 'band_name'. It is supported
+--- starting from version 2.10.0.
+--- - Field constraint is found in space 'bands', field 'year'. It is supported starting
+--- from version 2.10.0.
+--- ...
+--- ```
+---
+---@see box.schema.upgrade
+---
+---@param version string
+function box.schema.downgrade(version) end
+
+---Return a list of Tarantool versions available for downgrade.
+---
+---To learn how to downgrade a database to the specified Tarantool version, see [`box.schema.downgrade()`](lua://box.schema.downgrade).
+---
+---@see box.schema.downgrade
+function box.schmea.downgrade_versions() end
+
+---Return a list of downgrade issues for the specified Tarantool version.
+---
+---To learn how to downgrade a database to the specified Tarantool version, see [`box.schema.downgrade()`](lua://box.schema.downgrade).
+---
+---@param version string
+function box.schmea.downgrade_issues(version) end
+
+box.schema.user = {}
+
+---@alias box.schema.user.grant_object_type
+---| "space"
+---| "function"
+---| "sequence"
+---| "role"
+
+---@class box.schema.user.grant_options
+---@field if_not_exists? boolean
+---@field grantor? string
+
+---Grant privileges to a user or to another role.
+---
+---**Function: box.schema.role.grant(role-name, permissions, object-type, object-name [, option])**
+---box.schema.role.grant(role-name, permissions, 'universe' [, nil, option])
+---box.schema.role.grant(role-name, role-name [, nil, nil, option])
+---
+---Grant :ref:`privileges <authentication-owners_privileges>` to a role.
+---
+---:param string role-name: the name of the role
+---:param string permissions: one or more :ref:`permissions <access_control_list_privileges>` to grant to the role (for example, `read` or `read,write`)
+---:param string object-type: a database :ref:`object type <access_control_list_objects>` to grant permissions to (for example, `space`, `role`, or `function`)
+---:param string object-name: the name of a database object to grant permissions to
+---:param table option: `if_not_exists` = `true|false` (default = `false`) - boolean;
+---`true` means there should be no error if the role already
+---has the privilege
+---
+---The role must exist, and the object must exist.
+---
+---**Variation:** instead of `object-type, object-name` say `universe`
+---which means 'all object-types and all objects'. In this case, object name is omitted.
+---
+---**Variation:** instead of `permissions, object-type, object-name` say
+---`role-name` -- to grant a role to a role.
+---
+---**Example:**
+---
+--- ```lua
+--- -- Grant read/write privileges to a role --
+--- box.schema.role.grant('books_space_manager', 'read,write', 'space', 'books')
+--- -- Grant write privileges to a role --
+--- box.schema.role.grant('writers_space_reader', 'read', 'space', 'writers')
+--- ```
+---
+---@param user_name string
+---@param priv string
+---@param object_type box.schema.user.grant_object_type
+---@param object_name? string
+---@param options? box.schema.user.grant_options
+---@overload fun(user_name: string, priv: string, grant_object_type: "universe", options?: box.schema.user.grant_options?)
+---@overload fun(user_name: string, role: string, options?: box.schema.user.grant_options?)
+function box.schema.user.grant(user_name, priv, object_type, object_name, options) end

--- a/tarantool-annotations/Library/box/session.lua
+++ b/tarantool-annotations/Library/box/session.lua
@@ -1,0 +1,448 @@
+---@meta
+
+---# Builtin `box.session` submodule
+---
+---The `box.session` submodule allows querying the session state, writing to a session-specific temporary Lua table, or sending out-of-band messages, or setting up triggers which will fire when a session starts or ends.
+---
+---A *session* is an object associated with each client connection.
+box.session = {}
+
+
+---Return the unique identifier (ID) for the current session.
+---
+---The result can be 0 or -1 meaning there is no session.
+---
+---@return number
+function box.session.id() end
+
+
+---Check if session exists.
+---
+---@param id number
+---@return boolean exists true if the session exists, false if the session does not exist.
+function box.session.exists(id) end
+
+---This function works only if there is a peer, that is, if a connection has been made to a separate Tarantool instance.
+---
+---Possible errors: 'session.peer(): session does not exist'
+---
+---@param id? number
+---@return string | nil peer The host address and port of the session peer, for example “127.0.0.1:55457”.
+function box.session.peer(id) end
+
+---The value of the `sync` integer constant used in the [`binary protocol`](https://github.com/tarantool/tarantool/blob/2.1/src/box/iproto_constants.h).
+---
+---This value becomes invalid when the session is disconnected.
+---
+---This function is local for the request, i.e. not global for the session. If the connection behind the session is multiplexed, this function can be safely used inside the request processor.
+---
+---@return number
+function box.session.sync() end
+
+---Get the name of the current user.
+---
+---@return string user the name of current user
+function box.session.user() end
+
+---@alias box.session.type
+---| "binary"     # if the connection was done via the binary protocol
+---| "console"    # if the connection was done via the administrative console
+---| "repl"       # if the connection was done directly
+---| "applier"    # if the action is due to replication, regardless of how the connection was done
+---| "background" # if the action is in a background fiber
+
+---Get the type of connection or cause of action.
+---
+---@return box.session.type
+function box.session.type() end
+
+---Change Tarantool's current user.
+---
+---This is analogous to the Unix command `su`.
+---
+---Or, if function-to-execute is specified, change Tarantool's current user temporarily while executing the function -- this is analogous to the Unix command `sudo`.
+---
+---**Example:**
+--- ```tarantoolsession
+---
+--- tarantool> function f(a) return box.session.user() .. a end
+--- ---
+--- ...
+---
+--- tarantool> box.session.su('guest', f, '-xxx')
+--- ---
+--- - guest-xxx
+--- ...
+---
+--- tarantool> box.session.su('guest',function(...) return ... end,1,2)
+--- ---
+--- - 1
+--- - 2
+--- ...
+--- ```
+---
+---@param user string name of a target user
+---@param func? string name of a function, or definition of a function
+---@return any? ... result of the function
+function box.session.su(user, func) end
+
+---Get the user ID of the current user.
+---
+---@return number uid the user ID of the current user.
+function box.session.uid() end
+
+---Get the effective user ID of the current user.
+---
+---This is the same as [`box.session.uid`](lua://box.session.uid), except in two cases:
+---* The first case: if the call to `box.session.euid()` is within a function invoked by [`box.session.su`](lua://box.session.su) -- in that case, `box.session.euid()` returns the ID of the changed user. (the user who is specified by the `user-name` parameter of the `su` function)  but `box.session.uid()` returns the ID of the original user (the user who is calling the `su` function).
+---* The second case: if the call to `box.session.euid()` is within a function specified with [`box.schema.func.create`](lua://box.schema.func.create) and the binary protocol is in use -- in that case, `box.session.euid()` returns the ID of the user who created "function-name" but `box.session.uid()` returns the ID of the the user who is calling "function-name".
+---
+---**Example:**
+--- ```tarantoolsession
+---
+--- tarantool> box.session.su('admin')
+--- ---
+--- ...
+--- tarantool> box.session.uid(), box.session.euid()
+--- ---
+--- - 1
+--- - 1
+--- ...
+--- tarantool> function f() return {box.session.uid(),box.session.euid()} end
+--- ---
+--- ...
+--- tarantool> box.session.su('guest', f)
+--- ---
+--- - - 1
+--- - 0
+--- ...
+--- ```
+---
+---@return number euid the effective user ID of the current user.
+function box.session.euid() end
+
+---Session-specific storage.
+---
+---A Lua table that can hold arbitrary unordered session-specific names and values, which will last until the session ends.
+---
+---For example, this table could be useful to store current tasks when working with a [Tarantool queue manager](https://github.com/tarantool/queue).
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> box.session.peer(box.session.id())
+--- ---
+--- - 127.0.0.1:45129
+--- ...
+--- tarantool> box.session.storage.random_memorandum = "Don't forget the eggs"
+--- ---
+--- ...
+--- tarantool> box.session.storage.radius_of_mars = 3396
+--- ---
+--- ...
+--- tarantool> m = ''
+--- ---
+--- ...
+--- tarantool> for k, v in pairs(box.session.storage) do
+--- >   m = m .. k .. '='.. v .. ' '
+--- > end
+--- ---
+--- ...
+--- tarantool> m
+--- ---
+--- - 'radius_of_mars=3396 random_memorandum=Don't forget the eggs. '
+--- ...
+--- ```
+---
+---@type table<number|string,any>
+box.session.storage = {}
+
+---Define a trigger for execution when a new session is created.
+---
+---It may be fired due to an event such as [`console.connect`](lua://console.connect>).
+---
+---The trigger function will be the first thing executed after a new session is created. If the trigger execution fails and raises an error, the error is sent to the client and the connection is closed.
+---
+---Details about trigger characteristics are in the [`triggers`](<doc://triggers-box_triggers) section.
+---
+---**Warning:**
+---
+---If a trigger always results in an error, it may become impossible to connect to a server to reset it.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> function f ()
+--- >   x = x + 1
+--- > end
+--- tarantool> box.session.on_connect(f)
+--- ```
+---
+---@param trigger_func? fun()
+---@param old_trigger_func? fun()
+---@return fun()? removed_trigger If the parameters are (nil, old-trigger-function), then the old trigger is deleted.
+function box.session.on_connect(trigger_func, old_trigger_func) end
+
+---Define a trigger for execution after a client has disconnected.
+---
+---If the trigger function causes an error, the error is logged but otherwise is ignored. The trigger is invoked while the session associated with the client still exists and can access session properties, such as [`box.session.id`](lua://box.session.id).
+---
+---*Since 1.10* the trigger function is invoked immediately after the disconnect, even if requests that were made during the session have not finished.
+---
+---Details about trigger characteristics are in the [`triggers`](<doc://triggers-box_triggers) section.
+---
+---**Example #1:**
+---
+--- ```tarantoolsession
+--- tarantool> function f ()
+--- >   x = x + 1
+--- > end
+--- tarantool> box.session.on_disconnect(f)
+--- ```
+---
+---**Example #2:**
+---
+---After the following series of requests, a Tarantool instance will write a message using the [`log`](doc://log) module whenever any user connects or disconnects.
+---
+--- ```lua
+--- function log_connect()
+---     local log = require('log')
+---     local m = 'Connection. user=' .. box.session.user() .. ' id=' .. box.session.id()
+---     log.info(m)
+--- end
+---
+--- function log_disconnect()
+---     local log = require('log')
+---     local m = 'Disconnection. user=' .. box.session.user() .. ' id=' .. box.session.id()
+---     log.info(m)
+--- end
+---
+--- box.session.on_connect(log_connect)
+--- box.session.on_disconnect(log_disconnect)
+--- ```
+---
+---Here is what might appear in the log file in a typical installation:
+---
+--- ```lua
+--- 2014-12-15 13:21:34.444 [11360] main/103/iproto I>
+--- Connection. user=guest id=3
+--- 2014-12-15 13:22:19.289 [11360] main/103/iproto I>
+--- Disconnection. user=guest id=3
+--- ```
+---
+---@param trigger_func? fun()
+---@param old_trigger_func? fun()
+---@return fun()? removed_trigger If the parameters are (nil, old-trigger-function), then the old trigger is deleted.
+function box.session.on_disconnect(trigger_func, old_trigger_func) end
+
+---Define a trigger for execution during authentication.
+---
+---The `on_auth` trigger function is invoked in these circumstances:
+---* The :ref:`console.connect <console-connect>` function includes an authentication check for all users except 'guest'. For this case, the `on_auth` trigger function is invoked after the `on_connect` trigger function, if and only if the connection has succeeded so far.
+---* The [`binary protocol`](doc://admin-security) has a separate [`authentication packet`](doc://box_protocol-authentication). For this case, connection and authentication are considered to be separate steps.
+---
+---Unlike other trigger types, `on_auth` trigger functions are invoked **before** the event. Therefore a trigger function like `function auth_function () v = box.session.user(); end` will set `v` to `"guest"`, the user name before the authentication is done. To get the user name **after** the authentication is done, use the special syntax: `function auth_function (user_name) v = user_name; end`
+---
+---If the trigger fails by raising an error, the error is sent to the client and the connection is closed.
+---
+---Details about trigger characteristics are in the [`triggers`](<doc://triggers-box_triggers) section.
+---
+---**Example #1:**
+---
+--- ```tarantoolsession
+--- tarantool> function f ()
+--- >   x = x + 1
+--- > end
+--- tarantool> box.session.on_auth(f)
+--- ```
+---
+---**Example #2:**
+---
+---This is a more complex example, with two server instances. The first server instance listens on port 3301; its default user name is `'admin'`.
+---
+---There are three `on_auth` triggers:
+---* The first trigger has a function with no arguments, it can only look at `box.session.user()`.
+---* The second trigger has a function with a `user_name` argument, it can look at both of: `box.session.user()` and `user_name`.
+---* The third trigger has a function with a `user_name` argument and a `status` argument, it can look at all three of: `box.session.user()` and `user_name` and `status`.
+---
+---The second server instance will connect with [`console.connect`](lua://console.connect), and then will cause a display of the variables that were set by the trigger functions.
+---
+--- ```lua
+--- -- On the first server instance, which listens on port 3301
+--- box.cfg{listen=3301}
+--- function function1()
+---     print('function 1, box.session.user()='..box.session.user())
+--- end
+--- function function2(user_name)
+---     print('function 2, box.session.user()='..box.session.user())
+---     print('function 2, user_name='..user_name)
+--- end
+--- function function3(user_name, status)
+---     print('function 3, box.session.user()='..box.session.user())
+---     print('function 3, user_name='..user_name)
+---     if status == true then
+---         print('function 3, status = true, authorization succeeded')
+---     end
+--- end
+--- box.session.on_auth(function1)
+--- box.session.on_auth(function2)
+--- box.session.on_auth(function3)
+--- box.schema.user.passwd('admin')
+--- ```
+---
+--- ```lua
+--- -- On the second server instance, that connects to port 3301
+--- console = require('console')
+--- console.connect('admin:admin@localhost:3301')
+--- ```
+---
+---The result looks like this:
+---
+--- ```console
+--- function 3, box.session.user()=guest
+--- function 3, user_name=admin
+--- function 3, status = true, authorization succeeded
+--- function 2, box.session.user()=guest
+--- function 2, user_name=admin
+--- function 1, box.session.user()=guest
+--- ```
+---
+---@param trigger_func? fun()
+---@param old_trigger_func? fun()
+---@return fun()? removed_trigger If the parameters are (nil, old-trigger-function), then the old trigger is deleted.
+function box.session.on_auth(trigger_func, old_trigger_func) end
+
+---Define a trigger for reacting to user's attempts to execute actions that are not within the user's privileges.
+---
+---Details about trigger characteristics are in the [`triggers`](doc://triggers-box_triggers) section.
+---
+---**Example:**
+---
+---For example, server administrator can log restricted actions like this:
+---
+--- ```tarantoolsession
+--- tarantool> function on_access_denied(op, type, name)
+--- > log.warn('User %s tried to %s %s %s without required privileges', box.session.user(), op, type, name)
+--- > end
+--- ---
+--- ...
+--- tarantool> box.session.on_access_denied(on_access_denied)
+--- ---
+--- - 'function: 0x011b41af38'
+--- ...
+--- tarantool> function test() print('you shall not pass') end
+--- ---
+--- ...
+--- tarantool> box.schema.func.create('test')
+--- ---
+--- ...
+--- ```
+---
+---Then, when some user without required privileges tries to call `test()` and gets the error, the server will execute this trigger and write to log **"User *user_name* tried to Execute function test without required privileges"**.
+---@param trigger_func? fun()
+---@param old_trigger_func? fun()
+---@return fun()? removed_trigger If the parameters are (nil, old-trigger-function), then the old trigger is deleted.
+function box.session.on_access_denied(trigger_func, old_trigger_func) end
+
+---Generate an out-of-band message.
+---
+---*Deprecated since 3.0.0*
+---
+---By "out-of-band" we mean an extra message which supplements what is passed in a network via the usual channels. Although `box.session.push()` can be called at any time, in practice it is used with networks that are set up with [`net.box`](lua://net.box), and it is invoked by the server (on the "remote database system" to use our terminology for net.box), and the client has options for getting such messages.
+---
+---This function returns an error if the session is disconnected.
+---
+---If it is omitted, the default is the current `box.session.sync()` value. *Since 2.4.2*, `sync` is *deprecated* and its use will cause a warning. *Since 2.5.1*, its use will cause an error.
+---
+---* If the result is an error, then the first part of the return is `nil` and the second part is the error object.
+---* If the result is not an error, then the return is the boolean value `true`.
+---* When the return is `true`, the message has gone to the network buffer as a [`packet`](doc://box_protocol-iproto_protocol) with a different header code so the client can distinguish from an ordinary Okay response.
+---
+---The server's sole job is to call `box.session.push()`, there is no automatic mechanism for showing that the message was received.
+---
+---The client's job is to check for such messages after it sends something to the server. The major client methods -- [`conn:call`](lua://net.box.conn.call), [`conn:eval`](lua://net.box.conn.eval), [`conn:select`](lua://net.box.conn.select), [`conn:insert`](lua://net.box.conn.insert), [`conn:replace`](lua://net.box.conn.replace), [`conn:update`](lua://net.box.conn.update), [`conn:upsert`](lua://net.box.conn.upsert), [`conn:delete`](lua://net.box.conn.delete) -- may cause the server to send a message.
+---
+---Situation 1: when the client calls synchronously with the default `{async=false}` option. There are two optional additional options: `on_push={function-name}`, and :samp:`on_push_ctx={function-argument}`. When the client receives an out-of-band message for the session, it invokes "function-name(function-argument)". For example, with options `{on_push=table.insert, on_push_ctx=messages}`, the client will insert whatever it receives into a table named 'messages'.
+---
+---Situation 2: when the client calls asynchronously with the non-default `{async=true}` option. Here `on_push` and `on_push_ctx` are not allowed, but the messages can be seen by calling `pairs()` in a loop.
+---
+---Situation 2 complication: `pairs()` is subject to timeout. So there is an optional argument = timeout per iteration. If timeout occurs before there is a new message or a final response, there is an error return.
+---
+---To check for an error one can use the first loop parameter (if the loop starts with "for i, message in future:pairs()" then the first loop parameter is i). If it is `box.NULL` then the second parameter (in our example, "message") is the error object.
+---
+---**Example:**
+---
+--- ```lua
+--- -- Make two shells. On Shell#1 set up a "server", and
+--- -- in it have a function that includes box.session.push:
+--- box.cfg{listen=3301}
+--- box.schema.user.grant('guest','read,write,execute','universe')
+--- x = 0
+--- fiber = require('fiber')
+--- function server_function() x=x+1; fiber.sleep(1); box.session.push(x); end
+---
+--- -- On Shell#2 connect to this server as a "client" that
+--- -- can handle Lua (such as another Tarantool server operating
+--- -- as a client), and initialize a table where we'll get messages:
+--- net_box = require('net.box')
+--- conn = net_box.connect(3301)
+--- messages_from_server = {}
+---
+--- -- On Shell#2 remotely call the server function and receive
+--- -- a SYNCHRONOUS out-of-band message:
+--- conn:call('server_function', {},
+--- {is_async = false,
+--- on_push = table.insert,
+--- on_push_ctx = messages_from_server})
+--- messages_from_server
+--- -- After a 1-second pause that is caused by the fiber.sleep()
+--- -- request inside server_function, the result in the
+--- --  messages_from_server table will be: 1. Like this:
+--- -- tarantool> messages_from_server
+--- -- ---
+--- -- - - 1
+--- -- ...
+--- -- Good. That shows that box.session.push(x) worked,
+--- -- because we know that x was 1.
+---
+--- -- On Shell#2 remotely call the same server function and
+--- -- get an ASYNCHRONOUS out-of-band message. For this we cannot
+--- -- use on_push and on_push_ctx options, but we can use pairs():
+--- future = conn:call('server_function', {}, {is_async = true})
+--- messages = {}
+--- keys = {}
+--- for i, message in future:pairs() do
+---     table.insert(messages, message) table.insert(keys, i) end
+--- messages
+--- future:wait_result(1000)
+--- for i, message in future:pairs() do
+--- table.insert(messages, message) table.insert(keys, i) end
+--- messages
+--- -- There is no pause because conn:call does not wait for
+--- -- server_function to finish. The first time that we go through
+--- -- the pairs() loop, we see the messages table is empty. Like this:
+--- -- tarantool> messages
+--- -- ---
+--- -- - - 2
+--- --   - []
+--- -- ...
+--- -- That is okay because the server hasn't yet called
+--- -- box.session.push(). The second time that we go through
+--- -- the pairs() loop, we see the value of x at the time of
+--- -- the second call to box.session.push(). Like this:
+--- -- tarantool> messages
+--- -- ---
+--- -- - - 2
+--- --   - &0 []
+--- --   - 2
+--- --   - *0
+--- -- ...
+--- -- Good. That shows that the message was asynchronous, and
+--- -- that box.session.push() did its job.
+--- ```
+---
+---@deprecated
+---@param message tuple_type what to send
+---@param sync? number deprecated
+function box.session.push(message, sync) end
+

--- a/tarantool-annotations/Library/box/slab.lua
+++ b/tarantool-annotations/Library/box/slab.lua
@@ -1,0 +1,71 @@
+---@meta
+
+---# Builtin `box.slab` submodule
+---
+---The `box.slab` submodule provides access to slab allocator statistics.
+---
+---The slab allocator is the main allocator used to store [tuples](lua://box.tuple).
+---
+---This can be used to monitor the total memory usage and memory fragmentation.
+box.slab = {}
+
+---@class box.slab.info
+---@field quota_size number memory limit for slab allocator
+---@field quota_used number used by slab allocator
+---@field quota_used_ratio string
+---@field arena_size number allocated for both tuples and indexes
+---@field arena_used number used for both tuples and indexes
+---@field arena_used_ratio string
+---@field items_size number allocated only for tuples
+---@field items_used number used only for tuples
+---@field items_used_ratio string
+
+---Show an aggregated memory usage report in bytes for the slab allocator.
+---
+---This report is useful for assessing out-of-memory risks.
+---
+---`box.slab.info` gives a few ratios:
+---* `items_used_ratio`
+---* `arena_used_ratio`
+---* `quota_used_ratio`
+---
+---Here are two possible cases for monitoring memtx memory usage:
+---
+---**Case 1:** `0.5` < `items_used_ratio` < `0.9`
+---
+---Apparently your memory is highly fragmented. Check how many slab classes you have by looking at `box.slab.stats()` and counting the number of different classes. If there are many slab classes (more than a few dozens), you may run out of memory even though memory utilization is not high.
+---
+---While each slab may have few items used, whenever a tuple of a size different from any existing slab class size is allocated, Tarantool may need to get a new slab from the slab arena, and since the arena has few empty slabs left, it will attempt to increase its quota usage, which, in turn, may end up with an out-of-memory error due to the low remaining quota.
+---
+---**Case 2:** `items_used_ratio` > `0.9`
+---
+---You are running out of memory. All memory utilization indicators are high. Your memory is not fragmented, but there are few reserves left on each slab allocator level. You should consider increasing Tarantool's memory limit (`box.cfg.memtx_memory`).
+---
+---**To sum up:** your main out-of-memory indicator is `quota_used_ratio`.
+---
+---However, there are lots of perfectly stable setups with a high `quota_used_ratio`, so you only need to pay attention to it when both arena and item used ratio are also high.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> box.slab.info()
+--- ---
+--- - items_size: 228128
+--- items_used_ratio: 1.8%
+--- quota_size: 1073741824
+--- quota_used_ratio: 0.8%
+--- arena_used_ratio: 43.2%
+--- items_used: 4208
+--- quota_used: 8388608
+--- arena_size: 2325176
+--- arena_used: 1003632
+--- ...
+---
+--- tarantool> box.slab.info().arena_used
+--- ---
+--- - 1003632
+--- ...
+--- ```
+---
+---@return box.slab.info
+function box.slab.info() end

--- a/tarantool-annotations/Library/box/stat.lua
+++ b/tarantool-annotations/Library/box/stat.lua
@@ -1,0 +1,34 @@
+---@meta
+
+---@class box.stat.default
+---@field total number
+---@field rps number
+
+---@class box.stat.default_with_current: box.stat.default
+---@field current number
+
+---@class box.stat.net
+---@field SENT box.stat.default sent bytes to iproto
+---@field RECEIVED box.stat.default received bytes from iproto
+---@field CONNECTIONS box.stat.default_with_current iproto connections statistics
+---@field REQUESTS box.stat.default_with_current iproto requests statistics
+
+---@class box.stat
+---@field reset fun() # resets current statistics
+---@field net fun(): box.stat.net
+---@overload fun(): box.stat.info
+
+---@class box.stat.info
+---@field INSERT box.stat.default
+---@field DELETE box.stat.default
+---@field SELECT box.stat.default
+---@field REPLACE box.stat.default
+---@field UPDATE box.stat.default
+---@field UPSERT box.stat.default
+---@field CALL box.stat.default
+---@field EVAL box.stat.default
+---@field AUTH box.stat.default
+---@field ERROR box.stat.default
+
+---@type box.stat
+box.stat = {}

--- a/tarantool-annotations/Library/box/tuple.lua
+++ b/tarantool-annotations/Library/box/tuple.lua
@@ -1,0 +1,369 @@
+---@meta
+
+---@class box.tuple<T, U>: (T | U)
+local tuple_object = {}
+
+---Number of bytes in the tuple.
+---
+---If `t` is a tuple instance, `t:bsize()` will return the number of bytes in the tuple.
+---
+---With both the memtx storage engine and the vinyl storage engine the default maximum is one megabyte ([`memtx_max_tuple_size`](lua://cfg_storage-memtx_max_tuple_size) or [`vinyl_max_tuple_size`](cfg_storage-vinyl_max_tuple_size))
+---
+---Every field has one or more "length" bytes preceding the actual contents, so `bsize()` returns a value which is slightly greater than the sum of the lengths of the contents.
+---
+---The value does not include the size of "struct tuple" (for the current size of this structure look in the [tuple.h](https://github.com/tarantool/tarantool/blob/1.10/src/box/tuple.h) file in Tarantool's source code).
+---
+---**Example:**
+---
+---In the following example, a tuple named `t` is created which has three fields, and for each field it takes one byte to store the length and three bytes to store the contents, and then there is one more byte to store a count of the number of fields, so `bsize()` returns `3*(1+3)+1`. This is the same as the size of the string that `msgpack.encode({'aaa','bbb','ccc'})` would return.
+---
+--- ```tarantoolsession
+--- tarantool> t = box.tuple.new{'aaa', 'bbb', 'ccc'}
+--- ---
+--- ...
+--- tarantool> t:bsize()
+--- ---
+--- - 13
+--- ...
+--- ```
+---
+---@return number bytes
+function tuple_object:bsize() end
+
+---Find index of a value in the tuple
+---
+---If `t` is a tuple instance, `t:find(search-value)` returns the number of the first field in `t` that matches the search value, and `t:findall(search-value [, search-value ...])` returns numbers of all fields in `t` that match the search value. Optionally one can put a numeric argument `field-number` before the search-value to indicate "start searching at field number `field-number`".
+---
+---**Example:**
+---
+---In the following example, a tuple named `t` is created and then: the number of the first field in `t` which matches 'a' is returned, then the numbers of all the fields in `t` which match 'a' are returned, then the numbers of all the fields in t which match 'a' and are at or after the second field are returned.
+---
+--- ```tarantoolsession
+--- tarantool> t = box.tuple.new{'a', 'b', 'c', 'a'}
+--- ---
+--- ...
+--- tarantool> t:find('a')
+--- ---
+--- - 1
+--- ...
+--- tarantool> t:findall('a')
+--- ---
+--- - 1
+--- - 4
+--- ...
+--- tarantool> t:findall(2, 'a')
+--- ---
+--- - 4
+--- ...
+--- ```
+---
+---@param field_number_or_search_value? number
+---@param search_value? any
+---@return number
+function tuple_object:find(field_number_or_search_value, search_value) end
+
+---Find all indices of a value in the tuple
+---
+---If `t` is a tuple instance, `t:find(search-value)` returns the number of the first field in `t` that matches the search value, and `t:findall(search-value [, search-value ...])` returns numbers of all fields in `t` that match the search value. Optionally one can put a numeric argument `field-number` before the search-value to indicate "start searching at field number `field-number`".
+---
+---**Example:**
+---
+---In the following example, a tuple named `t` is created and then: the number of the first field in `t` which matches 'a' is returned, then the numbers of all the fields in `t` which match 'a' are returned, then the numbers of all the fields in t which match 'a' and are at or after the second field are returned.
+---
+--- ```tarantoolsession
+--- tarantool> t = box.tuple.new{'a', 'b', 'c', 'a'}
+--- ---
+--- ...
+--- tarantool> t:find('a')
+--- ---
+--- - 1
+--- ...
+--- tarantool> t:findall('a')
+--- ---
+--- - 1
+--- - 4
+--- ...
+--- tarantool> t:findall(2, 'a')
+--- ---
+--- - 4
+--- ...
+--- ```
+---
+---@param field_number_or_search_value? number
+---@param search_value? any
+---@return number[]
+function tuple_object:findall(field_number_or_search_value, search_value) end
+
+---Lua `next()` function, but for a tuple object.
+---
+---When called without arguments, `tuple:next()` returns the first field from a tuple. Otherwise, it returns the field next to the indicated position.
+---
+---However `tuple:next()` is not really efficient, and it is better to use [`tuple:pairs()/ipairs()`](lua://box.tuple.pairs).
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> tuple = box.tuple.new({5, 4, 3, 2, 0})
+--- ---
+--- ...
+---
+--- tarantool> tuple:next()
+--- ---
+--- - 1
+--- - 5
+--- ...
+---
+--- tarantool> tuple:next(1)
+--- ---
+--- - 2
+--- - 4
+--- ...
+---
+--- tarantool> ctx, field = tuple:next()
+--- ---
+--- ...
+---
+--- tarantool> while field do
+--- > print(field)
+--- > ctx, field = tuple:next(ctx)
+--- > end
+--- 5
+--- 4
+--- 3
+--- 2
+--- 0
+--- ---
+--- ...
+--- ```
+---
+---@see box.tuple.pairs
+---@see box.tuple.ipairs
+---
+---@param pos? number
+---@return number field_number, any value
+function tuple_object:next(pos) end
+
+---Get a tuple iterator
+---
+---In Lua, [`lua-table-value:pairs()`](https://www.lua.org/pil/7.3.html) is a method which returns: `function`, `lua-table-value`, `nil`.
+---
+---Tarantool has extended this so that `tuple-value:pairs()` returns: `function`, `tuple-value`, `nil`. It is useful for Lua iterators, because Lua iterators traverse a value's components until an end marker is reached.
+---
+---`tuple_object:ipairs()` is the same as `pairs()`, because tuple fields are always integers.
+---
+---In the following example, a tuple named `t` is created and then all its fields are selected using a Lua for-end loop.
+---
+--- ```tarantoolsession
+--- tarantool> t = box.tuple.new{'Fld#1', 'Fld#2', 'Fld#3', 'Fld#4', 'Fld#5'}
+--- ---
+--- ...
+--- tarantool> tmp = ''
+--- ---
+--- ...
+--- tarantool> for k, v in t:pairs() do
+--- >   tmp = tmp .. v
+--- > end
+--- ---
+--- ...
+--- tarantool> tmp
+--- ---
+--- - Fld#1Fld#2Fld#3Fld#4Fld#5
+--- ...
+--- ```
+---
+---@see box.tuple.ipairs
+---
+---@return fun() ctx, any tuple_value, nil
+function tuple_object:pairs() end
+
+---Get a tuple iterator
+---
+---In Lua, [`lua-table-value:pairs()`](https://www.lua.org/pil/7.3.html) is a method which returns: `function`, `lua-table-value`, `nil`.
+---
+---Tarantool has extended this so that `tuple-value:pairs()` returns: `function`, `tuple-value`, `nil`. It is useful for Lua iterators, because Lua iterators traverse a value's components until an end marker is reached.
+---
+---`tuple_object:ipairs()` is the same as `pairs()`, because tuple fields are always integers.
+---
+---In the following example, a tuple named `t` is created and then all its fields are selected using a Lua for-end loop.
+---
+--- ```tarantoolsession
+--- tarantool> t = box.tuple.new{'Fld#1', 'Fld#2', 'Fld#3', 'Fld#4', 'Fld#5'}
+--- ---
+--- ...
+--- tarantool> tmp = ''
+--- ---
+--- ...
+--- tarantool> for k, v in t:pairs() do
+--- >   tmp = tmp .. v
+--- > end
+--- ---
+--- ...
+--- tarantool> tmp
+--- ---
+--- - Fld#1Fld#2Fld#3Fld#4Fld#5
+--- ...
+--- ```
+---
+---@see box.tuple.pairs
+---
+---@return fun() ctx, any tuple_value, nil
+function tuple_object:ipairs() end
+
+---If t is a tuple instance, `t:totable()` will return all fields, `t:totable(1)` will return all fields starting with field number 1, t:totable(1,5) will return all fields between field number 1 and field number 5.
+---It is preferable to use t:totable() rather than t:unpack().
+---
+---@param start_field_number? number
+---@param end_field_number? number
+---@return any[]
+function tuple_object:totable(start_field_number, end_field_number) end
+
+-- TODO: Extend generic support to allow inferring tomap() type better.
+
+---The `tuple_object:totable()` function only returns a table containing the values. But the `tuple_object:tomap()` function returns a table containing not only the values, but also the key:value pairs.
+---
+---This only works if the tuple comes from a space that has been formatted with a format clause.
+---
+---@param options? { names_only: boolean }
+---@return T | U
+function tuple_object:tomap(options) end
+
+---Update a tuple.
+---
+---This function updates a tuple which is not in a space. Compare the function [`box.space.<space-name>:update(<key>, {{<format>, <field_no>, <value>}}, ...})`](lua://box.space.update) which updates a tuple in a space.
+---
+---For details: see the description for `operator`, `field_no`, and `value` in the section :ref:`box.space.space-name:update{key, format,
+---{field_number, value}...) <box_space-update>`.
+---
+---If the original tuple comes from a space that has been formatted with a [format clause](lua://box.space.format), the formatting will be preserved for the result tuple.
+---
+---In the following example, a tuple named `t` is created and then its second field is updated to equal 'B'.
+---
+--- ```tarantoolsession
+--- tarantool> t = box.tuple.new{'Fld#1', 'Fld#2', 'Fld#3', 'Fld#4', 'Fld#5'}
+--- ---
+--- ...
+--- tarantool> t:update({{'=', 2, 'B'}})
+--- ---
+--- - ['Fld#1', 'B', 'Fld#3', 'Fld#4', 'Fld#5']
+--- ...
+--- ```
+---
+---*Since 2.3* a tuple can also be updated via [JSON paths](json.paths).
+---
+---@param update_operations [box.update_operation, number|string, tuple_type][]
+---@return box.tuple
+function tuple_object:update(update_operations) end
+
+---Get information about the tuple memory usage.
+---
+---**Note:** `waste_size` is provided for reference only and can be inaccurate. Avoid using it for memory usage calculations.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> box.space.tester:get('222200000'):info()
+--- ---
+--- - data_size: 55
+--- waste_size: 95
+--- arena: memtx
+--- field_map_size: 4
+--- header_size: 6
+--- ...
+--- ```
+---
+---@return {
+---     data_size: number,
+---     header_size: number,
+---     field_map_size: number,
+---     waste_size: number,
+---     arena: 'memtx' | 'malloc' | 'runtime'
+---}
+function tuple_object:info() end
+
+---# Builtin `box.tuple` submodule
+---
+---The `box.tuple` submodule provides read-only access for the `tuple` userdata type. It allows, for a single [tuple](lua://box.tuple): selective retrieval of the field contents, retrieval of information about size, iteration over all the fields, and conversion to a [Lua table](https://www.lua.org/pil/2.5.html).
+---
+---**How to convert tuples to/from Lua tables:**
+---
+---This function illustrates how to convert tuples to/from Lua tables and lists of scalars:
+---
+--- ```lua
+--- tuple = box.tuple.new({scalar1, scalar2, ... scalar_n}) -- scalars to tuple
+--- lua_table = {tuple:unpack()}                            -- tuple to Lua table
+--- lua_table = tuple:totable()                             -- tuple to Lua table
+--- scalar1, scalar2, ... scalar_n = tuple:unpack()         -- tuple to scalars
+--- tuple = box.tuple.new(lua_table)                        -- Lua table to tuple
+--- ```
+---
+---Then it will find the field that contains 'b', remove that field from the tuple,
+---and display how many bytes remain in the tuple. The function uses Tarantool
+---`box.tuple` functions `new()`, `unpack()`, `find()`, `transform()`,
+---`bsize()`.
+---
+--- ```lua
+--- function example()
+---     local tuple1, tuple2, lua_table_1, scalar1, scalar2, scalar3, field_number
+---     local luatable1 = {}
+---     tuple1 = box.tuple.new({'a', 'b', 'c'})
+---     luatable1 = tuple1:totable()
+---     scalar1, scalar2, scalar3 = tuple1:unpack()
+---     tuple2 = box.tuple.new(luatable1[1],luatable1[2],luatable1[3])
+---     field_number = tuple2:find('b')
+---     tuple2 = tuple2:transform(field_number, 1)
+---     return 'tuple2 = ' , tuple2 , ' # of bytes = ' , tuple2:bsize()
+--- end
+--- ```
+---
+---... And here is what happens when one invokes the function:
+---
+--- ```tarantoolsession
+--- tarantool> example()
+--- ---
+--- - tuple2 =
+--- - ['a', 'c']
+--- - ' # of bytes = '
+--- - 5
+--- ...
+--- ```
+box.tuple = {}
+
+---Construct a new tuple from either a scalar or a Lua table.
+---
+---Alternatively, one can get new tuples from Tarantool's [`select`](lua://box.space.select) or [`insert`](lua://box.space.insert) or [`replace`](box.space.replace) or [`update`](box.space.update) requests, which can be regarded as statements that do `new()` implicitly.
+---
+---**Example:**
+---
+---In the following example, `x` will be a new table object containing one tuple and `t` will be a new tuple object. Saying `t` returns the entire tuple `t`.
+---
+--- ```tarantoolsession
+--- tarantool> x = box.space.tester:insert{
+--- >   33,
+--- >   tonumber('1'),
+--- >   tonumber64('2')
+--- > }:totable()
+--- ---
+--- ...
+--- tarantool> t = box.tuple.new{'abc', 'def', 'ghi', 'abc'}
+--- ---
+--- ...
+--- tarantool> t
+--- ---
+--- - ['abc', 'def', 'ghi', 'abc']
+--- ...
+--- ```
+---
+---@overload fun(...: tuple_type): box.tuple<any, any>
+---@param value tuple_type[]
+---@return box.tuple<any, any> tuple
+function box.tuple.new(value) end
+
+---Check whether a given object is a tuple cdata object.
+---
+---*Since 2.2.3, 2.3.2, and 2.4.1*
+---
+---Never raises nor returns an error.
+---
+---@param object any
+---@return boolean is_tuple returns true if given object is box.tuple
+function box.tuple.is(object) end

--- a/tarantool-annotations/Library/clock.lua
+++ b/tarantool-annotations/Library/clock.lua
@@ -1,0 +1,213 @@
+---@meta
+
+---# Builtin `clock` module
+---
+---The `clock` module returns time values derived from the Posix / C CLOCK_GETTIME_ function or equivalent. Most functions in the module return a number of seconds; functions whose names end in "64" return a 64-bit number of nanoseconds.
+local clock = {}
+
+---Get the wall clock time in seconds.
+---
+---The wall clock time. Derived from C function `clock_gettime(CLOCK_REALTIME)`.
+---
+---**Example:**
+---
+--- ```lua
+--- -- This will print an approximate number of years since 1970.
+--- clock = require('clock')
+--- print(clock.time() / (365*24*60*60))
+--- ```
+---
+---@return number
+function clock.time() end
+
+---Get the wall clock time in seconds.
+---
+---The wall clock time. Derived from C function `clock_gettime(CLOCK_REALTIME)`.
+---
+---**Example:**
+---
+--- ```lua
+--- -- This will print an approximate number of years since 1970.
+--- clock = require('clock')
+--- print(clock.realtime() / (365*24*60*60))
+--- ```
+---
+---@return number
+function clock.realtime() end
+
+---Get the wall clock time in nanoseconds.
+---
+---The wall clock time. Derived from C function `clock_gettime(CLOCK_REALTIME)`.
+---
+---**Example:**
+---
+--- ```lua
+--- -- This will print an approximate number of years since 1970.
+--- clock = require('clock')
+--- print(clock.time() / (365*24*60*60))
+--- ```
+---
+---@return uint64_t
+function clock.time64() end
+
+---Get the wall clock time in nanoseconds.
+---
+---The wall clock time. Derived from C function `clock_gettime(CLOCK_REALTIME)`.
+---
+---**Example:**
+---
+--- ```lua
+--- -- This will print an approximate number of years since 1970.
+--- clock = require('clock')
+--- print(clock.realtime() / (365*24*60*60))
+--- ```
+---
+---@return uint64_t
+function clock.realtime64()	end
+
+---Get the monotonic time in seconds.
+---
+---The monotonic time. Derived from C function `clock_gettime(CLOCK_MONOTONIC)`.
+---
+---Monotonic time is similar to wall clock time but is not affected by changes to or from daylight saving time, or by changes done by a user.
+---
+---This is the best function to use with benchmarks that need to calculate elapsed time.
+---
+---**Example:**
+---
+--- ```lua
+--- -- This will print seconds since the start.
+--- clock = require('clock')
+--- print(clock.monotonic())
+--- ```
+---
+---@see clock.monotonic64
+---
+---@return number
+function clock.monotonic() end
+
+---Get the monotonic time in nanoseconds.
+---
+---The monotonic time. Derived from C function `clock_gettime(CLOCK_MONOTONIC)`.
+---
+---Monotonic time is similar to wall clock time but is not affected by changes to or from daylight saving time, or by changes done by a user.
+---
+---This is the best function to use with benchmarks that need to calculate elapsed time.
+---
+---**Example:**
+---
+--- ```lua
+--- -- This will print nanoseconds since the start.
+--- clock = require('clock')
+--- print(clock.monotonic64())
+--- ```
+---
+---@see clock.monotonic
+---
+---@return uint64_t
+function clock.monotonic64() end
+
+---Get the processor time in seconds.
+---
+---Derived from C function `clock_gettime(CLOCK_PROCESS_CPUTIME_ID)`.
+---
+---This is the best function to use with benchmarks that need to calculate how much time has been spent within a CPU.
+---
+---**Example:**
+---
+--- ```lua
+--- -- This will print seconds in the CPU since the start.
+--- clock = require('clock')
+--- print(clock.proc())
+--- ```
+---
+---@see clock.proc64
+---
+---@return number
+function clock.proc() end
+
+---Get the processor time in nanoseconds.
+---
+---Derived from C function `clock_gettime(CLOCK_PROCESS_CPUTIME_ID)`.
+---
+---This is the best function to use with benchmarks that need to calculate how much time has been spent within a CPU.
+---
+---**Example:**
+---
+--- ```lua
+--- -- This will print nanoseconds in the CPU since the start.
+--- clock = require('clock')
+--- print(clock.proc64())
+--- ```
+---
+---@see clock.proc
+---
+---@return uint64_t
+function clock.proc64() end
+
+---Get the thread time in seconds.
+---
+---The thread time. Derived from C function `clock_gettime(CLOCK_THREAD_CPUTIME_ID)`.
+---
+---This is the best function to use with benchmarks that need to calculate how much time has been spent within a thread within a CPU.
+---
+---**Example:**
+---
+--- ```lua
+--- -- This will print seconds in the thread since the start.
+--- clock = require('clock')
+--- print(clock.thread())
+--- ```
+---
+---@see clock.thread64
+---
+---@return number
+function clock.thread() end
+
+---Get the thread time in nanoseconds.
+---
+---The thread time. Derived from C function `clock_gettime(CLOCK_THREAD_CPUTIME_ID)`.
+---
+---This is the best function to use with benchmarks that need to calculate how much time has been spent within a thread within a CPU.
+---
+---**Example:**
+---
+--- ```lua
+--- -- This will print nanoseconds in the thread since the start.
+--- clock = require('clock')
+--- print(clock.thread64())
+--- ```
+---
+---@see clock.thread
+---
+---@return uint64_t
+function clock.thread64() end
+
+---Measure the time a function takes within a processor.
+---
+---The time that a function takes within a processor. This function uses `clock.proc()`, therefore it calculates elapsed CPU time. Therefore it is not useful for showing actual elapsed time.
+---
+---**Example:**
+---
+--- ```lua
+--- -- Benchmark a function which sleeps 10 seconds.
+--- -- NB: bench() will not calculate sleep time.
+--- -- So the returned value will be {a number less than 10, 88}.
+--- clock = require('clock')
+--- fiber = require('fiber')
+--- function f(param)
+---   fiber.sleep(param)
+---   return 88
+--- end
+--- clock.bench(f, 10)
+--- ```
+---
+---@see clock.proc
+---
+---@generic T...
+---@param func fun(...: T...)
+---@param ... T...
+---@return table
+function clock.bench(func, ...) end
+
+return clock

--- a/tarantool-annotations/Library/config.lua
+++ b/tarantool-annotations/Library/config.lua
@@ -1,0 +1,195 @@
+---@meta
+
+---# Builtin `config` module
+---
+---*Since 3.0.0*
+---
+---The `config` module provides the ability to work with an instance's configuration.
+---
+---For example, you can determine whether the current instance is up and running without errors after applying the [cluster's configuration](doc://configuration_overview).
+---
+---By using the `config.storage` [role](doc://configuration_application_roles), you can set up a Tarantool-based [centralized configuration storage](doc://configuration_etcd) and interact with this storage using the `config` module API.
+local config = {}
+
+
+---Get a configuration applied to the current or remote instance.
+---
+---Note the following differences between getting a configuration for the current and remote instance:
+---* For the current instance, `get()` returns its configuration considering [environment variables](doc://configuration_environment_variable).
+---* For a remote instance, `get()` only considers a cluster configuration and ignores environment variables.
+---
+---**Examples:**
+---
+---The example below shows how to get the full instance configuration:
+---
+--- ```tarantoolsession
+--- app:instance001> require('config'):get()
+--- ---
+--- - fiber:
+---   io_collect_interval: null
+---   too_long_threshold: 0.5
+---   top:
+---   enabled: false
+---   # Other configuration values
+---   # ...
+--- ```
+---
+---This example shows how to get an `iproto.listen` option value:
+---
+--- ```tarantoolsession
+--- app:instance001> require('config'):get('iproto.listen')
+--- ---
+--- - - uri: 127.0.0.1:3301
+--- ...
+--- ```
+---
+---`config.get()` can also be used in [application code](doc://configuration_application) to get the value of a custom configuration option.
+---
+---@param param string | string[]
+---@param opts { instance?: string }
+---@return any
+function config:get(param, opts) end
+
+---@alias config.info.status
+---| "ready" # the configuration is applied successfully
+---| "check_warnings" # the configuration is applied with warnings
+---| "check_errors" # the configuration cannot be applied due to configuration errors
+
+---@class config.alert
+---@field type "warn" | "error"
+---@field message string
+
+---@class config.info.meta
+---@field etcd? { mod_revision: { [string]: number }, revision: integer }
+---@field storage? { mod_revision: { [string]: number }, revision: integer }
+
+---@class config.info.meta.v2
+---@field last config.info.meta
+---@field active config.info.meta
+
+---@class config.info
+---@field status config.info.status
+---@field alerts config.alert[]
+---@field meta config.info.meta
+
+---@class config.info.v2: config.info
+---@field meta config.info.meta.v2
+
+---Get the current instance's state in regard to configuration.
+---
+---Below are a few examples demonstrating how the `info()` output might look.
+---
+---**Example: no configuration warnings or errors**
+---
+---In the example below, an instance's state is `ready` and no warnings are shown:
+---
+--- ```tarantoolsession
+--- app:instance001> require('config'):info('v2')
+--- ---
+--- - status: ready
+---   meta:
+---     last: &0 []
+---     active: *0
+---   alerts: []
+--- ...
+--- ```
+---
+---**Example: configuration warnings**
+--- 
+---In the example below, the instance's state is `check_warnings`.
+---The `alerts` section informs that privileges to the `bands` space for `sampleuser` cannot be granted because the `bands` space has not been created yet:
+--- 
+--- ```tarantoolsession
+--- app:instance001> require('config'):info('v2')
+--- ---
+--- - status: check_warnings
+---   meta:
+---     last: &0 []
+---     active: *0
+---   alerts:
+---   - type: warn
+---     message: box.schema.user.grant("sampleuser", "read,write", "space", "bands") has
+---     failed because either the object has not been created yet, a database schema
+---     upgrade has not been performed, or the privilege write has failed (separate
+---     alert reported)
+---     timestamp: 2024-07-03T18:09:18.826138+0300
+--- ...
+--- ```
+---
+---This warning is cleared when the `bands` space is created.
+---
+---**Example: configuration errors**
+---
+---In the example below, the instance's state is `check_errors`.
+---The `alerts` section informs that the `log.level` configuration option has an incorrect value:
+---
+--- ```tarantoolsession
+--- app:instance001> require('config'):info('v2')
+--- ---
+--- - status: check_errors
+---   meta:
+---     last: []
+---     active: []
+---   alerts:
+---   - type: error
+---     message: '[cluster_config] log.level: Got 8, but only the following values are
+---     allowed: 0, fatal, 1, syserror, 2, error, 3, crit, 4, warn, 5, info, 6, verbose,
+---     7, debug'
+---     timestamp: 2024-07-03T18:13:19.755454+0300
+--- ...
+--- ```
+--- 
+---**Example: configuration errors (centralized configuration storage)**
+--- 
+---In this example, the `meta` field includes information about a [centralized storage](doc://configuration_etcd) the instance takes a configuration from:
+--- 
+--- ```tarantoolsession
+--- app:instance001> require('config'):info('v2')
+--- ---
+--- - status: check_errors
+---   meta:
+---     last:
+---       etcd:
+---         mod_revision:
+---           /myapp/config/all: 5
+---         revision: 5
+---     active:
+---       etcd:
+---         mod_revision:
+---           /myapp/config/all: 2
+---         revision: 4
+---   alerts:
+---   - type: error
+---     message: 'etcd source: invalid config at key "/myapp/config/all": [cluster_config]
+---     groups.group001.replicasets.replicaset001.instances.instance001.log.level: Got
+---     8, but only the following values are allowed: 0, fatal, 1, syserror, 2, error,
+---     3, crit, 4, warn, 5, info, 6, verbose, 7, debug'
+---     timestamp: 2024-07-03T15:22:06.438275Z
+---     ...
+--- ```
+---
+---@param version? 'v1'
+---@return config.info
+---@overload fun(version: 'v2'): config.info.v2
+function config:info(version) end
+
+
+---Get a URI of the current or remote instance.
+---
+---**Note:** the resulting URI object can be passed to the [connect()](lua://net_box-connect) function.
+---
+---**Example:**
+---
+---The example below shows how to get a URI used to advertise `storage-b-003` to other cluster members:
+---
+--- ```lua
+--- local config = require('config')
+--- config:instance_uri('peer', { instance = 'storage-b-003' })
+--- ```
+---
+---@param uri_type 'peer' | 'sharding'
+---@param opts { instance?: string }
+---@return uri
+function config:instace_uri(uri_type, opts) end
+
+return config

--- a/tarantool-annotations/Library/console.lua
+++ b/tarantool-annotations/Library/console.lua
@@ -1,0 +1,125 @@
+---@meta
+--luacheck: ignore
+--TODO:
+
+---# Builtin `console` module
+---
+---The console module allows one Tarantool instance to access another Tarantool instance, and allows one Tarantool instance to start listening on an `admin port`.
+local console = {}
+
+---Connect to the instance at URI.
+---
+---Change the prompt from '`tarantool>`' to ':samp:`{uri}>`', and act henceforth as a client until the user ends the session or types `control-D`.
+---
+---The console.connect function allows one Tarantool instance, in interactive mode, to access another Tarantool instance. Subsequent requests will appear to be handled locally, but in reality the requests are being sent to the remote instance and the local instance is acting as a client. Once connection is successful, the prompt will change and subsequent requests are sent to, and executed on, the remote instance. Results are displayed on the local instance. To return to local mode, enter `control-D`.
+---
+---If the Tarantool instance at `uri` requires authentication, the connection might look something like: `console.connect('admin:secretpassword@distanthost.com:3301')`.
+---
+---There are no restrictions on the types of requests that can be entered, except those which are due to privilege restrictions -- by default the login to the remote instance is done with user name = 'guest'. The remote instance could allow for this by granting at least one privilege: `box.schema.user.grant('guest','execute','universe')`.
+---
+---**Possible errors:** the connection will fail if the target Tarantool instance was not initiated with `box.cfg{listen=...}`.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> console = require('console')
+--- ---
+--- ...
+--- tarantool> console.connect('198.18.44.44:3301')
+--- ---
+--- ...
+--- 198.18.44.44:3301> -- prompt is telling us that instance is remote
+--- ```
+---
+---@param uri uri_like
+function console.connect(uri) end
+
+---Listen for incoming requests.
+---
+---The primary way of listening for incoming requests is via the connection-information string, or URI, specified in `box.cfg{listen=...}`.
+---
+---The alternative way of listening is via the URI specified in `console.listen(...)`. This alternative way is called
+---"administrative" or simply :ref:`"admin port" <admin-security>`.
+---The listening is usually over a local host with a Unix domain socket.
+---
+---:param string uri: the URI of the local instance
+---
+---The "admin" address is the URI to listen on. It has no default value, so it
+---must be specified if connections will occur via an admin port. The parameter
+---is expressed with URI = Universal Resource Identifier format, for example
+---"/tmpdir/unix_domain_socket.sock", or a numeric TCP port. Connections are
+---often made with telnet. A typical port value is 3313.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> console = require('console')
+--- ---
+--- ...
+--- tarantool> console.listen('unix/:/tmp/X.sock')
+--- ... main/103/console/unix/:/tmp/X I> started
+--- ---
+--- - fd: 6
+--- name:
+--- host: unix/
+--- family: AF_UNIX
+--- type: SOCK_STREAM
+--- protocol: 0
+--- port: /tmp/X.sock
+--- ...
+--- ```
+---
+---@param uri uri_like
+function console.listen(uri) end
+
+---Start the console on the current interactive terminal.
+---
+---**Example:**
+---
+---A special use of `console.start()` is with [`initialization files`](doc://index-init_label).
+---
+---Normally, if one starts the Tarantool instance with tarantool initialization file there is no console. This can be
+---remedied by adding these lines at the end of the initialization file:
+---
+--- ```lua
+--- local console = require('console')
+--- console.start()
+--- ```
+function console.start() end
+
+---Set the auto-completion flag.
+---
+---If auto-completion is `true`, and the user is using Tarantool as a client or the user is using Tarantool via `console.connect()`, then hitting the TAB key may cause tarantool to complete a word automatically. The default auto-completion value is `true`.
+---
+---@param auto_completion_flag boolean
+function console.ac(auto_completion_flag) end
+
+---Set a custom end-of-request marker for Tarantool console.
+--- 
+---The default end-of-request marker is a newline (line feed).
+---
+---Custom markers are not necessary because Tarantool can tell when a multi-line request has not ended (for example, if it sees that a function declaration does not have an end keyword). Nonetheless for special needs, or for entering multi-line requests in older Tarantool versions, you can change the end-of-request marker. As a result, newline alone is not treated as end of request.
+function console.delimiter(marker) end
+
+---Get default output format.
+---
+---Return the current default output format.
+---
+---@return { fmt: "yaml" | "lua" } format
+function console.get_default_output() end
+
+---Set default output format.
+---
+---@param format { fmt: "yaml" | "lua" }
+function console.set_default_output(format) end
+
+---Set or access the end-of-output string if default output is 'lua'.
+---
+---This is the string that appears at the end of output in a response to any Lua request.
+---
+---The default value is `;` semicolon. Saying `eos()` will return the current value.
+---
+---For example, after `require('console').eos('!!')` responses will end with '!!'.
+function console.eos(str) end
+
+return console

--- a/tarantool-annotations/Library/decimal.lua
+++ b/tarantool-annotations/Library/decimal.lua
@@ -1,0 +1,126 @@
+---@meta
+
+---# Builtin `decimal` module
+---
+---The `decimal` module has functions for working with exact numbers.
+---
+---This is important when numbers are large or even the slightest inaccuracy is unacceptable.
+---
+---**Example:** Lua calculates `0.16666666666667 * 6` with floating-point so the result is 1.
+---
+---But with the decimal module (using `decimal.new` to convert the number to decimal type) `decimal.new('0.16666666666667') * 6` is 1.00000000000002.
+local decimal = {}
+
+---@alias decimal_like decimal | string | number
+
+---@class decimal
+---@operator unm: decimal
+---@operator add(decimal_like): decimal
+---@operator sub(decimal_like): decimal
+---@operator mul(decimal_like): decimal
+---@operator div(decimal_like): decimal
+---@operator mod(decimal_like): decimal
+---@operator pow(decimal_like): decimal
+local decimal_obj = {}
+
+---Returns absolute value of a decimal number.
+---
+---**Example:** if `a` is `-1` then `decimal.abs(a)` returns `1`.
+---
+---@param n decimal_like
+---@return decimal
+function decimal.abs(n) end
+
+---Returns e raised to the power of a decimal number.
+---
+---**Example:** if `a` is `1` then `decimal.exp(a)` returns `2.7182818284590452353602874713526624978`.
+---
+---Compare `math.exp(1)` from the Lua math library, which returns `2.718281828459`.
+---
+---@param n decimal_like
+---@return decimal
+function decimal.exp(n) end
+
+---Check if the object is decimal.
+---
+---Returns `true` if the specified value is a decimal, and `false` otherwise.
+---
+---**Example:** if `a` is `123` then `decimal.is_decimal(a)` returns `false`.
+---
+---If `a` is `decimal.new(123)` then `decimal.is_decimal(a)` returns `true`.
+---
+---@param n any
+---@return boolean
+function decimal.is_decimal(n) end
+
+---Get natural logarithm of a decimal number.
+---
+---**Example:** if `a` is `1` then `decimal.ln(a)` returns `0`.
+---
+---@param n decimal_like
+---@return decimal
+function decimal.ln(n) end
+
+---Get the value of the input as a decimal number.
+---
+---**Example:** if `a` is `1E-1` then `decimal.new(a)` returns `0.1`.
+---
+---@param n decimal_like
+---@return decimal
+function decimal.new(n) end
+
+
+---Get the number of digits of a decimal number.
+---
+---**Example:** if `a` is `123.4560` then `decimal.precision(a)` returns `7`.
+---
+---@param n decimal_like
+---@return number
+function decimal.precision(n) end
+
+---Evaluate rounding or padding to a fixed amount of the post-decimal digits of a decimal number.
+---
+---If the number of post-decimal digits is greater than new-scale, then rounding occurs. The rounding rule is: round half away from zero.
+---
+---If the number of post-decimal digits is less than new-scale, then padding of zeros occurs.
+---
+---**Example:** if `a` is `-123.4550` then `decimal.rescale(a, 2)`  returns `-123.46`, and `decimal.rescale(a, 5)` returns `-123.45500`.
+---
+---@param n decimal
+---@param new_scale number
+---@return decimal
+function decimal.rescale(n, new_scale) end
+
+---Get the number of post-decimal digits of a decimal number.
+---
+---**Example:** if `a` is `123.4560` then `decimal.scale(a)` returns `4`.
+---
+---@param n decimal_like
+---@return number scale
+function decimal.scale(n, new_scale) end
+
+---Get the number of digits of a decimal number.
+---
+---**Example:** if `a` is `123.4560` then `decimal.precision(a)` returns `7`.
+---
+---@param n decimal_like
+---@return decimal
+function decimal.log10(n) end
+
+---Calculate the square root of a decimal number.
+---
+---**Example:** if `a` is `2` then `decimal.sqrt(a)` returns `1.4142135623730950488016887242096980786`.
+---
+---@param n decimal_like
+---@return decimal
+function decimal.sqrt(n) end
+
+---Remove trailing post-decimal zeros of a decimal number.
+---
+---**Example:** if `a` is `2.20200` then `decimal.trim(a)` returns `2.202`.
+---
+---@param n decimal
+---@return decimal
+function decimal.trim(n) end
+
+return decimal

--- a/tarantool-annotations/Library/fiber.lua
+++ b/tarantool-annotations/Library/fiber.lua
@@ -1,0 +1,634 @@
+---@meta
+
+---# Builtin `fiber` module
+---
+---With the fiber module, you can:
+---
+---* Create, run, and manage fibers.
+---* Send and receive messages between different processes (i.e. different connections, sessions, or fibers) via channels.
+---* Use a synchronization mechanism for fibers, similar to "condition variables" and similar to operating-system functions, such as `pthread_cond_wait()` plus `pthread_cond_signal()`.
+fiber = {}
+
+---Create and start a fiber.
+---
+---The fiber is created and begins to run immediately.
+---
+---**Example:**
+---
+---The script below shows how to create a fiber using `fiber.create`.
+---
+--- ```lua
+--- -- app.lua --
+--- fiber = require('fiber')
+--- 
+--- function greet(name)
+--- print('Hello, '..name)
+--- end
+--- 
+--- greet_fiber = fiber.create(greet, 'John')
+--- print('Fiber already started')
+--- ```
+---
+---@async
+---@generic T...
+---@param func fun(...:any) the function to be associated with the fiber
+---@vararg ... what will be passed to function
+---@return fiber
+function fiber.create(func, ...) end
+
+---Create a fiber but do not start it.
+---
+---The created fiber starts after the fiber creator (that is, the job that is calling `fiber.new()`) yields. The initial fiber state is ready.
+---
+---**Note:** `fiber.status()` returns the suspended state for ready fibers because the ready state is not observable using the fiber module API.
+---
+---You can join fibers created using `fiber.new()` by calling the `fiber_object:join()` function and get the result returned by the fiber's function.
+---
+---To join the fiber, you need to make it joinable using `fiber_object:set_joinable()`.
+---
+---@generic T...
+---@param func fun(...: T...) the function to be associated with the fiber
+---@vararg T... what will be passed to function
+---@return fiber
+function fiber.new(func, ...) end
+
+---Get the currently scheduled fiber.
+---
+---@return fiber
+function fiber.self() end
+
+---Get a fiber object by ID.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> fiber.find(101)
+--- ---
+--- - status: running
+--- name: interactive
+--- id: 101
+--- ...
+--- ```
+---
+---@param id number numeric identifier of the fiber.
+---@return fiber
+function fiber.find(id) end
+
+---Yield control to the scheduler and sleep for the specified number of seconds.
+---
+---Only the current fiber can be made to sleep.
+---
+---**Example:**
+---
+---The `increment` function below contains an infinite loop that adds 1 to the `counter` global variable. Then, the current fiber goes to sleep for `period` seconds. `sleep` causes an implicit [`fiber.yield()`](lua://fiber.yield).
+---
+--- ```lua
+--- -- app.lua --
+--- fiber = require('fiber')
+--- 
+--- counter = 0
+--- function increment(period)
+---     while true do
+---         counter = counter + 1
+---         fiber.sleep(period)
+---     end
+--- end
+--- 
+--- increment_fiber = fiber.create(increment, 2)
+--- require('console').start()
+--- ```
+---
+---@async
+---@param timeout number number of seconds to sleep.
+function fiber.sleep(timeout) end
+
+---Yield control to the scheduler.
+---
+---Equivalent to `fiber.sleep(0)`.
+---
+---**Example:**
+---
+---In the example below, two fibers are associated with the same function. Each fiber yields control after printing a greeting.
+---
+--- ```lua
+--- -- app.lua --
+--- fiber = require('fiber')
+--- 
+--- function greet()
+---     while true do
+---         print('Enter a name:')
+---         name = io.read()
+---         print('Hello, '..name..'. I am fiber '..fiber.id())
+---         fiber.yield()
+---     end
+--- end
+--- 
+--- for i = 1, 2 do
+---     fiber_object = fiber.create(greet)
+---     fiber_object:cancel()
+--- end
+--- ```
+---
+---@async
+function fiber.yield() end
+
+---Return the status of the current fiber.
+---
+---Or, if optional fiber_object is passed, return the status of the specified fiber.
+---
+--- ```tarantoolsession
+--- tarantool> fiber.status()
+--- ---
+--- - running
+--- ...
+--- ```
+---
+---@param fiber_object? fiber
+---@return "running" | "dead" | "supspected"
+function fiber.status(fiber_object) end
+
+---@class fiber.info
+---@field csw number number of context switches.
+---@field memory { total: number, used: number } `total` is memory occupied by the fiber as a C structure, its stack, etc. `actual` is memory used by the fiber.
+---@field time number duplicates the “time" entry from fiber.top().cpu for each fiber. (Only shown if fiber.top is enabled.)
+---@field name string name of the fiber
+---@field fid number id of the fiber
+---@field backtrace { C: string, L: string }[] fiber's stack trace
+
+---Return information about all fibers.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> fiber.info({ bt = true })
+--- ---
+--- - 101:
+--- csw: 1
+--- backtrace:
+--- - C: '#0  0x5dd130 in lbox_fiber_id+96'
+--- - C: '#1  0x5dd13d in lbox_fiber_stall+13'
+--- - L: stall in =[C] at line -1
+--- - L: (unnamed) in @builtin/fiber.lua at line 59
+--- - C: '#2  0x66371b in lj_BC_FUNCC+52'
+--- - C: '#3  0x628f28 in lua_pcall+120'
+--- - C: '#4  0x5e22a8 in luaT_call+24'
+--- - C: '#5  0x5dd1a9 in lua_fiber_run_f+89'
+--- - C: '#6  0x45b011 in fiber_cxx_invoke(int (*)(__va_list_tag*), __va_list_tag*)+17'
+--- - C: '#7  0x5ff3c0 in fiber_loop+48'
+--- - C: '#8  0x81ecf4 in coro_init+68'
+--- memory:
+--- total: 516472
+--- used: 0
+--- time: 0
+--- name: lua
+--- fid: 101
+--- 102:
+--- csw: 0
+--- backtrace:
+--- - C: '#0  (nil) in +63'
+--- - C: '#1  (nil) in +63'
+--- memory:
+--- total: 516472
+--- used: 0
+--- time: 0
+--- name: on_shutdown
+--- fid: 102
+--- 
+--- ...
+--- ```
+---
+---@param opts? { backtrace?: boolean, bt?: boolean }
+---@return table<number, fiber.info>
+function fiber.info(opts) end
+
+---@return number fiber_id returns current fiber id
+function fiber.id() end
+
+---@class fiber.top
+---@field instant number (in percent) a number which indicates the share of time the fiber was executing during the previous event loop iteration
+---@field average number (in percent) a number which is calculated as an exponential moving average of instant values over all the previous event loop iterations
+---@field time number (in seconds) a number which estimates how much CPU time each fiber spent processing during its lifetime
+
+---Show all alive fibers and their CPU consumption.
+---
+---**Note:** *Since 2.11.0* `cpu_misses` is deprecated and always returns `0`.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> fiber.top()
+--- ---
+--- - cpu:
+--- 107/lua:
+--- instant: 30.967324490456
+--- time: 0.351821993
+--- average: 25.582738345233
+--- 104/lua:
+--- instant: 9.6473633128437
+--- time: 0.110869897
+--- average: 7.9693406131877
+--- 101/on_shutdown:
+--- instant: 0
+--- time: 0
+--- average: 0
+--- 103/lua:
+--- instant: 9.8026528631511
+--- time: 0.112641118
+--- average: 18.138387232255
+--- 106/lua:
+--- instant: 20.071174377224
+--- time: 0.226901357
+--- average: 17.077908441831
+--- 102/interactive:
+--- instant: 0
+--- time: 9.6858e-05
+--- average: 0
+--- 105/lua:
+--- instant: 9.2461986412164
+--- time: 0.10657528
+--- average: 7.7068458630827
+--- 1/sched:
+--- instant: 20.265286315108
+--- time: 0.237095335
+--- average: 23.141537169257
+--- cpu_misses: 0
+--- ...
+--- ```
+---
+---@return { cpu: table<string,fiber.top>, cpu_misses: number }
+function fiber.top() end
+
+---Cancel a fiber.
+---
+---Locate a fiber by its numeric ID and cancel it. In other words, [`fiber.kill()`](lua://fiber.kill) combines [`fiber.find()`](fiber.find) and [`fiber_object:cancel()`](lua://fiber_object.cancel).
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> fiber.kill(fiber.id()) -- kill self, may make program end
+--- ---
+--- - error: fiber is cancelled
+--- ...
+--- ```
+---
+---@param fiber_object fiber
+function fiber.kill(fiber_object) end
+
+---Check if the current fiber has been cancelled and throw an exception if this is the case.
+---
+---**Note:**
+---
+---Even if you catch the exception, the fiber will remain cancelled. Most types of calls will check `fiber.testcancel()`. However, some functions (`id`, `status`, `join` etc.) will return no error.
+---
+---We recommend application developers to implement occasional checks with [`fiber.testcancel()`](lua://fiber.testcancel) and to end fiber's execution as soon as possible in case it has been cancelled.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> fiber.testcancel()
+--- ---
+--- - error: fiber is cancelled
+--- ...
+--- ```
+-
+function fiber.testcancel() end
+
+---Get the current system time (in seconds since the epoch) as a Lua number.
+---
+---The time is taken from the event loop clock, which makes this call very cheap, but still useful for constructing artificial tuple keys.
+---
+---**Example:**
+---
+--- ```
+--- tarantool> fiber.time(), fiber.time()
+--- - 1448466279.2415
+--- - 1448466279.2415
+--- ```
+---
+---@see fiber.time64
+---
+---@return number
+function fiber.time() end
+
+---Get the current system time (in microseconds since the epoch) as a 64-bit integer.
+---
+---The time is taken from the event loop clock.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> fiber.time(), fiber.time64()
+--- ---
+--- - 1448466351.2708
+--- - 1448466351270762
+--- ...
+--- ```
+---
+---@see fiber.time
+---
+---@return int64_t
+function fiber.time64() end
+
+---Get the monotonic time in seconds.
+---
+---It is better to use `fiber.clock()` for calculating timeouts instead of `fiber.time()` because `fiber.time()` reports real time so it is affected by system time changes.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> start = fiber.clock()
+--- ---
+--- ...
+--- tarantool> print(start)
+--- 248700.58805
+--- ---
+--- ...
+--- tarantool> print(fiber.time(), fiber.time()-start)
+--- 1600785979.8291 1600537279.241
+--- ---
+--- ...
+--- ```
+---
+---@see fiber.clock64
+---
+---@return number
+function fiber.clock() end
+
+---Get the monotonic time in seconds.
+---
+---Same as `fiber.clock()` but in microseconds.
+---
+---@see fiber.clock
+---
+---@return ffi.cdata*
+function fiber.clock64() end
+
+---Enable `fiber.top`.
+---
+---**Note:** Enabling `fiber.top()` slows down fiber switching by about 15%, so it is disabled by default.
+---
+---@see fiber.top
+function fiber.top_enable() end
+
+---Disable `fiber.top`.
+---
+---**Note:** Enabling `fiber.top()` slows down fiber switching by about 15%, so it is disabled by default.
+---
+---@see fiber.top
+function fiber.top_disable() end
+
+---Check whether a slice for the current fiber is over.
+---
+---A fiber slice limits the time period of executing a fiber without yielding control.
+---
+---**Example:**
+---
+---The example below shows how to use `set_max_slice` to limit the slice for all fibers. `fiber.check_slice()` is called inside a long-running operation to determine whether a slice for the current fiber is over.
+---
+--- ```lua
+--- -- app.lua --
+--- fiber = require('fiber')
+--- clock = require('clock')
+---
+--- fiber.set_max_slice({warn = 1.5, err = 3})
+--- time = clock.monotonic()
+--- function long_operation()
+---     while clock.monotonic() - time < 5 do
+---         fiber.check_slice()
+---         -- Long-running operation ⌛⌛⌛ --
+---     end
+--- end
+--- 
+--- long_operation_fiber = fiber.create(long_operation)
+--- ```
+---
+---The output should look as follows:
+---
+--- ```console
+--- $ tarantool app.lua
+--- fiber has not yielded for more than 1.500 seconds
+--- FiberSliceIsExceeded: fiber slice is exceeded
+--- ```
+---
+function fiber.check_slice() end
+
+---@class fiber.slice
+---@field warn number
+---@field err number
+
+---Set a slice for the current fiber execution.
+---
+---A fiber slice limits the time period of executing a fiber without yielding control.
+---@param slice fiber.slice|number a time period (in seconds) that specifies the error slice
+function fiber.set_slice(slice) end
+
+---Set the default maximum slice for all fibers.
+---
+---A fiber slice limits the time period of executing a fiber without yielding control.
+---
+---
+---@param slice fiber.slice|number a time period (in seconds) that specifies the error slice
+function fiber.set_max_slice(slice) end
+
+---Extend a slice for the current fiber execution.
+---For example, if the default error slice is set using fiber.set_max_slice() to 3 seconds, extend_slice(1)
+---extends the error slice to 4 seconds.
+---@param slice fiber.slice|number a time period (in seconds) that specifies the error slice
+function fiber.extend_slice(slice) end
+
+---@class fiber: userdata
+local fiber_object = {}
+
+---Get a fiber's ID
+---
+---@return number # fiber id
+function fiber_object:id() end
+
+---Get or change a fiber's name
+---
+---Change the fiber name. By default a Tarantool server's interactive-mode fiber is named 'interactive' and new fibers created due to [`fiber.create`](lua://fiber.create) are named 'lua'.
+---
+---Giving fibers distinct names makes it easier to distinguish them when using [`fiber.info`](lua://fiber.info) and [`fiber.top()`](lua://fiber.top).
+---
+---Max length is 255.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> fiber.self():name('non-interactive')
+--- ---
+--- ...
+--- ```
+---
+---@param name? string
+---@param options? {truncate: boolean}
+---@return string name
+function fiber_object:name(name, options) end
+
+---Get a fiber's status.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> fiber.self():status()
+--- ---
+--- - running
+--- ...
+--- ```
+---
+---@return "dead" | "running" | "suspended"
+function fiber_object:status() end
+
+---Send a cancellation request to the fiber.
+---
+---Running and suspended fibers can be cancelled. After a fiber has been cancelled, attempts to operate on it cause errors, for example, [`fiber_object:name()`](fiber_object.name) causes `error: the fiber is dead`. But a dead fiber can still report its ID and status.
+---
+---Cancellation is asynchronous.
+---
+---Use [`fiber_object:join()`](fiber_object.join) to wait for the cancellation to complete.
+---
+---After `fiber_object:cancel()` is called, the fiber may or may not check whether it was cancelled. If the fiber does not check it, it cannot ever be cancelled.
+---
+---**Possible errors:** cancel is not permitted for the specified fiber object.
+---
+function fiber_object:cancel() end
+
+---Local storage within the fiber.
+fiber_object.storage = {}
+
+---Make a fiber joinable.
+---
+---A joinable fiber can be waited for using [`fiber_object:join()`](lua://fiber_object.join{.
+---
+---The best practice is to call `fiber_object:set_joinable()` before the fiber function begins to execute because otherwise the fiber could become `dead` before `fiber_object:set_joinable()` takes effect.
+---
+---The usual sequence could be:
+---1. Call `fiber.new()` instead of `fiber.create()` to create a new fiber_object. Do not yield at this point, because that will cause the fiber function to begin.
+---2. Call `fiber_object:set_joinable(true)` to make the new `fiber_object` joinable. Now it is safe to yield.
+---3. Call `fiber_object:join()`.
+---
+---Usually `fiber_object:join()` should be called, otherwise the fiber's status may become 'suspended' when the fiber function ends, instead of 'dead'.
+---
+---@param true_or_false boolean
+function fiber_object:set_joinable(true_or_false) end
+
+---"Join" a joinable fiber.
+---
+---That is, let the fiber's function run and wait until the fiber's status is ‘dead' (normally a status becomes ‘dead' when the function execution finishes).
+---
+---Joining will cause a yield, therefore, if the fiber is currently in a suspended state, execution of its fiber function will resume.
+---
+---This kind of waiting is more convenient than going into a loop and periodically checking the status.
+---
+---However, it works only if the fiber was created with `fiber.new()` and was made joinable with `fiber_object:set_joinable()`.
+---
+---@async
+---@return boolean success, any ...
+function fiber_object:join() end
+
+---@class fiber.channel
+local channel_object = {}
+
+---Create a communication channel.
+---
+---@param capacity? number the maximum number of slots (spaces for channel:put messages) that can be in use at once. The default is 0.
+---@return fiber.channel
+function fiber.channel(capacity) end
+
+---Send a message using a channel.
+---
+---If the channel is full, `channel:put()` waits until there is a free slot in the channel.
+---
+---**Note:**
+---
+---The default [`channel capacity`](lua://fiber.channel) is `0`.
+---
+---With this default value, `channel:put()` *waits infinitely* until `channel:get()` is called.
+---
+---@async
+---@param message any
+---@param timeout? number
+---@return boolean success If timeout is specified, and there is no free slot in the channel for the duration of the timeout, then the return value is false. If the channel is closed, then the return value is false. Otherwise, the return value is true, indicating success.
+function channel_object:put(message, timeout) end
+
+---Close the channel.
+---
+---All waiters in the channel will stop waiting.
+---
+---All following `channel:get()` operations will return `nil`, and all following `channel:put()` operations will return `false`.
+function channel_object:close() end
+
+---Fetch and remove a message from a channel.
+---
+---If the channel is empty, `channel:get()` waits for a message.
+---
+---@async
+---@param timeout? number maximum number of seconds to wait for a message. Default: infinity.
+---@return any message
+function channel_object:get(timeout) end
+
+---Check whether the channel is empty (has no messages).
+---
+---@return boolean # is_empty
+function channel_object:is_empty() end
+
+---Find out how many messages are in the channel.
+---
+---@return number
+function channel_object:count() end
+
+---Returns size of channel.
+---
+---@return number
+function channel_object:size() end
+
+---Check if a channel is full.
+---
+---@return boolean # is_full
+function channel_object:is_full() end
+
+---Check whether readers are waiting for a message because they have issued `channel:get()` and the channel is empty.
+---
+---@return boolean
+function channel_object:has_readers() end
+
+---Check whether writers are waiting because they have issued `channel:put()` and the channel is full.
+---
+---@return boolean
+function channel_object:has_writers() end
+
+---Check if a channel is closed.
+---
+---@return boolean
+function channel_object:is_closed() end
+
+---@class fiber.cond: userdata
+local cond_object = {}
+
+---Create a new conditional variable.
+---
+---@return fiber.cond
+function fiber.cond() end
+
+---Make the current fiber go to sleep.
+---
+---Waiting until another fiber invokes the `signal()` or `broadcast()` method on the cond object.
+---
+---The sleep causes an implicit `fiber.yield()`.
+---
+---@async
+---@param timeout? number number of seconds to wait, default = forever.
+---@return boolean was_signalled If timeout is provided, and a signal doesn't happen for the duration of the timeout, wait() returns false. If a signal or broadcast happens, wait() returns true.
+function cond_object:wait(timeout) end
+
+---Wake up a single fiber that has executed `wait()` for the same variable.
+---
+---Does not yield.
+function cond_object:signal() end
+
+---Wake up all fibers that have executed `wait()` for the same variable.
+---
+---Does not yield.
+function cond_object:broadcast() end
+
+return fiber

--- a/tarantool-annotations/Library/fio.lua
+++ b/tarantool-annotations/Library/fio.lua
@@ -1,0 +1,528 @@
+---@meta
+
+---# Builtin `fio` module
+---
+---Tarantool supports file input/output with an API that is similar to POSIX syscalls. All operations are performed asynchronously. Multiple fibers can access the same file simultaneously.
+---
+---* Functions for common pathname manipulations.
+---* Functions for directory or file existence and type checks.
+---* Functions for common file manipulations.
+---* Constants which are the same as POSIX flag values (for example `fio.c.flag.O_RDONLY` = POSIX O_RDONLY).
+
+local fio = {}
+
+---Concatenate partial string, separated by '/' to form a path name.
+---
+---**Example:** `fio.pathjoin('/etc', 'default', 'myfile')` => `'/etc/default/myfile'`
+---@vararg string ...
+---@return string
+function fio.pathjoin(...) end
+
+---Get a file name.
+---
+---Given a full path name, remove all but the final part (the file name). Also remove the suffix, if it is passed.
+---
+---Note that the basename of a path with a trailing slash is an empty string. It is different from how the Unix basename program interprets such a path.
+---
+---**Example:**
+---
+---`fio.basename('/path/to/my.lua', '.lua')` => `'my'`
+---
+---@param path_name string path name
+---@param suffix? string suffix
+---@return string file_name
+function fio.basename(path_name, suffix) end
+
+---Get a directory name.
+---
+---**Example:**
+---
+---`fio.dirname('/path/to/my.lua')` => `'/path/to/'`
+---
+---@param path_name string path-name
+---@return string
+function fio.dirname(path_name) end
+
+---Get a directory and file name.
+---
+---Given a full path name, remove the final part (the file name).
+---
+---**Example:**
+---
+---`fio.abspath('my.lua')` => `'/path/to/my.lua'`
+---
+---@param file_name string
+---@return string directory_name that is, path name including file name.
+function fio.abspath(file_name) end
+
+---Check if file or directory exists.
+---
+---@param path string
+---@return boolean # `true` if path-name refers to a directory or file that exists and is not a broken symbolic link; otherwise `false`.
+function fio.path.exists(path) end
+
+---Check if file or directory is a directory.
+---
+---@param path string
+---@return boolean # `true` if path-name refers to a directory; otherwise `false`.
+function fio.path.is_dir(path) end
+
+---Check if file or directory is a file.
+---
+---@param path string
+---@return boolean # `true` if path-name refers to a file; otherwise `false`
+function fio.path.is_file(path) end
+
+---Check if file or directory is a link.
+---
+---@param path string
+---@return boolean # `true` if path-name refers to a symbolic link; otherwise `false`
+function fio.path.is_link(path) end
+
+---Check if file or directory exists.
+---
+---@param path string
+---@return boolean # `true` if path-name refers to a directory or file that exists or is a broken symbolic link; otherwise `false`
+function fio.path.lexists(path) end
+
+---Set the mask bits used when creating files or directories.
+---
+---For a detailed description type `man 2 umask`.
+---
+---@param mask_bits number
+---@return number # previous mask bits
+function fio.umask(mask_bits) end
+
+---@class fio.stat:table
+---@field inode number
+---@field rdev number
+---@field size number
+---@field atime number
+---@field mode number
+---@field mtime number
+---@field nlink number
+---@field uid number
+---@field blksize number
+---@field gid number
+---@field ctime number
+---@field dev number
+---@field blocks number
+
+---Get information about a file object.
+---
+---Returns information about a file object. For details type `man 2 lstat` or `man 2 stat`.
+---
+---**Example:**
+---
+--- `fio.lstat('/etc')`
+---
+--- ```yaml
+---   inode: 1048577
+---   rdev: 0
+---   size: 12288
+---   atime: 1421340698
+---   mode: 16877
+---   mtime: 1424615337
+---   nlink: 160
+---   uid: 0
+---   blksize: 4096
+---   gid: 0
+---   ctime: 1424615337
+---   dev: 2049
+---   blocks: 24
+--- ```
+---
+---@param path string path name of file.
+---@return fio.stat
+function fio.lstat(path) end
+
+---Get information about a file object.
+---
+---Returns information about a file object. For details type `man 2 lstat` or `man 2 stat`.
+---
+---@param path string path name of file.
+---@return fio.stat
+function fio.stat(path) end
+
+---Create directory.
+---
+---**Example:**
+---
+---`fio.mkdir('/etc')` => `false`
+---
+---@param path_name string path of directory.
+---@param mode? number Mode bits can be passed as a number or as string constants, for example S_IWUSR. Mode bits can be combined by enclosing them in braces.
+---@return boolean success, string error_message?
+function fio.mkdir(path_name, mode) end
+
+---Delete a directory
+---
+---@param path_name string
+---@return boolean success, string message?
+function fio.rmdir(path_name) end
+
+---Change working directory.
+---
+---**Example:**
+---
+---`fio.chdir('/etc')` => `true`
+---
+---@param path_name string path of directory.
+---@return boolean success
+function fio.chdir(path_name) end
+
+---List files in a directory.
+---
+---The result is similar to the ls shell command.
+---
+---@param path_name string  path of directory.
+---@return string[]|nil, string? error_message #
+function fio.listdir(path_name) end
+
+---Get files whose names match a given string.
+---
+---Return a list of files that match an input string.
+---
+---The list is constructed with a single flag that controls the behavior of the function: GLOB_NOESCAPE.
+---
+---For details type `man 3 glob`.
+---
+---**Example:**
+---
+--- `fio.glob('/etc/x*')`
+--- ```
+--- - - /etc/xdg
+---   - /etc/xml
+---   - /etc/xul-ext
+--- ```
+---@return string[] list list of files whose names match the input string
+function fio.glob(path_name) end
+
+---Return the name of a directory that can be used to store temporary files.
+---
+---`fio.tempdir()` stores the created temporary directory into `/tmp` by default.
+---
+---*Since 2.4.1*, this can be changed by setting the `TMPDIR` environment variable.
+---
+---Before starting Tarantool, or at runtime by `os.setenv()`.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> fio.tempdir()
+--- ---
+--- - /tmp/lG31e7
+--- ...
+--- tarantool> fio.mkdir('./mytmp')
+--- ---
+--- - true
+--- ...
+---
+--- tarantool> os.setenv('TMPDIR', './mytmp')
+--- ---
+--- ...
+---
+--- tarantool> fio.tempdir()
+--- ---
+--- - ./mytmp/506Z0b
+--- ```
+---@return string
+function fio.tempdir() end
+
+---Get the name of the current working directory.
+---
+---**Example:**
+---
+---`fio.cwd()` => `'/home/username/tarantool_sandbox'`
+---
+---@return string
+function fio.cwd() end
+
+---Copy everything in the `from-path`, including subdirectory contents, to the `to-path`.
+---
+---The result is similar to the `cp -r` shell command.
+---
+---The `to-path` should not be empty.
+---@param from_path string
+---@param to_path string
+---@return boolean success, string? error_message
+function fio.copytree(from_path, to_path) end
+
+---Create the path, including parent directories, but without file contents.
+---
+---The result is similar to the `mkdir -p` shell command.
+---
+---**Example:**
+---
+---`fio.mktree('/home/archives')` => `true`
+---
+---@param path_name string
+---@return boolean success, string? error_message
+function fio.mktree(path_name) end
+
+---Delete directories.
+---
+---**Example:**
+---
+---`fio.rmtree('/home/archives')` => `true`
+---
+---@param path_name string
+---@return boolean success, string? error_message
+function fio.rmtree(path_name) end
+
+---Creates link
+---@param src string existing file name.
+---@param dst string linked name.
+---@return boolean success, string? error_message
+function fio.link(src, dst) end
+
+---Creates link.
+---
+---@param src string existing file name.
+---@param dst string linked name.
+---@return boolean success, string? error_message
+function fio.symlink(src, dst) end
+
+---Reads link.
+---
+---@param src string path to the link
+---@return string link_source
+function fio.readlink(src) end
+
+---Deletes link or file.
+---
+---@param path_name string
+---@return boolean success, string? error_message
+function fio.unlink(path_name) end
+
+---Rename a file or directory.
+---
+---@param path_name string original name.
+---@param new_path_name string new name.
+---@return boolean success, string? error_message
+function fio.rename(path_name, new_path_name) end
+
+---Change the access time and possibly also change the update time of a file.
+---
+---For details type man 2 utime.
+---
+---Times should be expressed as number of seconds since the epoch.
+---
+---@param file_name string name.
+---@param accesstime? number time of last access. default current time.
+---@param updatetime? number time of last update. default = access time.
+---@return boolean success, string? error_message
+function fio.utime(file_name, accesstime, updatetime) end
+
+---Copy a file. The result is similar to the cp shell command.
+---
+---@param path_name string path to original file.
+---@param new_path_name string path to new file.
+---@return boolean success, string? error_message
+function fio.copyfile(path_name, new_path_name) end
+
+---Manage rights to and ownership of file objects.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> fio.chown('/home/username/tmp.txt', 'username', 'username')
+--- - true
+--- ```
+---
+---@param owner_user string new username.
+---@param owner_group string new groupname.
+---@return boolean success, string? error_message
+function fio.chown(path_name, owner_user, owner_group) end
+
+---Manage rights to and ownership of file objects.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> fio.chmod('/home/username/tmp.txt', tonumber('0755', 8))
+--- - true
+--- ```
+---@param path_name string
+---@param new_rights number new permissions
+---@return boolean success, string? error_message
+function fio.chmod(path_name, new_rights) end
+
+---Reduce the file size.
+---
+---@param path_name string
+---@param new_size number
+---@return boolean success, string? error_message
+function fio.truncate(path_name, new_size) end
+
+---Ensure that changes are written to disk.
+---
+---@return boolean success
+function fio.sync() end
+
+---Open a file.
+---
+---@param path_name string
+---@param flags? number|flags|flags[]
+---@param mode? number
+---@return fio.file, box.error err?
+function fio.open(path_name, flags, mode) end
+
+---@class fio.file
+local file_handle = {}
+
+---Close a file.
+---
+---@return boolean success, string? error_message
+function file_handle:close() end
+
+---Perform random-access read on a file.
+---
+---@overload fun(buffer: ffi.cdata*, count: number, offset: number): number
+---@param count number number of bytes to read
+---@param offset number offset within file where reading begins
+---@return string
+function file_handle:pread(count, offset) end
+
+---Perform random-access write on a file.
+---
+---@overload fun(buffer: ffi.cdata*, count: number, offset: number): number
+---@param new_string string value to write (if the format is pwrite(new-string, offset))
+---@param offset number offset within file where writing begins
+---@return boolean success, string? error_message
+function file_handle:pwrite(new_string, offset) end
+
+---Perform non-random-access read on a file.
+---
+---@overload fun(buffer: ffi.cdata*, count: number): number
+---@param count? number number of bytes to read
+---@return string buffer
+function file_handle:read(count) end
+
+---Perform non-random-access write on a file.
+---
+---@overload fun(buffer: ffi.cdata*, count: number): boolean
+---@param new_string string
+---@return boolean success
+function file_handle:write(new_string) end
+
+---Change the size of an open file.
+---
+---@param new_size number
+---@return boolean success, string? error_message
+function file_handle:truncate(new_size) end
+
+---Change position in a file.
+---
+---@param position number position to seek to
+---@param offset_from? seek
+---
+---`SEEK_END` = end of file,
+---
+---`SEEK_CUR` = current position,
+---
+---`SEEK_SET` = start of file.
+---@return number # the new position if success
+function file_handle:seek(position, offset_from) end
+
+---Get statistics about an open file.
+---
+---@return fio.stat
+function file_handle:stat() end
+
+---Ensure that changes made to an open file are written to disk.
+---
+---@return boolean success, string? error_message
+function file_handle:fsync() end
+
+---Ensure that changes made to an open file are written to disk.
+---
+---@return boolean success, string? error_message
+function file_handle:fdatasync() end
+
+---@alias seek
+---| 'SEEK_SET'
+---| 'SEEK_DATA'
+---| 'SEEK_HOLE'
+---| 'SEEK_END'
+---| 'SEEK_CUR'
+
+---@alias mode
+---| 'S_IWGRP'
+---| 'S_IXGRP'
+---| 'S_IROTH'
+---| 'S_IXOTH'
+---| 'S_IRUSR'
+---| 'S_IXUSR'
+---| 'S_IRWXU'
+---| 'S_IRWXG'
+---| 'S_IWOTH'
+---| 'S_IRWXO'
+---| 'S_IWUSR'
+---| 'S_IRGRP'
+
+---@alias flags
+---| 'O_APPEND' # (start at end of file)
+---| 'O_ASYNC' # (signal when IO is possible)
+---| 'O_CLOEXEC' # (enable a flag related to closing)
+---| 'O_CREAT' # (create file if it doesn’t exist)
+---| 'O_DIRECT' # (do less caching or no caching)
+---| 'O_DIRECTORY' # (fail if it’s not a directory)
+---| 'O_EXCL' # (fail if file cannot be created)
+---| 'O_LARGEFILE' # (allow 64-bit file offsets)
+---| 'O_NDELAY'
+---| 'O_NOATIME' # (no access-time updating)
+---| 'O_NOCTTY' # (no console tty)
+---| 'O_NOFOLLOW' # (no following symbolic links)
+---| 'O_NONBLOCK' # (no blocking)
+---| 'O_PATH' # (get a path for low-level use)
+---| 'O_RDONLY' # (read only)
+---| 'O_RDWR' # (either read or write)
+---| 'O_SYNC' # (force writing if it’s possible)
+---| 'O_TMPFILE' # (the file will be temporary and nameless)
+---| 'O_TRUNC' # (truncate)
+---| 'O_WRONLY' # (write only)
+
+
+fio.c = {
+    seek = {
+        SEEK_SET = 0,
+        SEEK_DATA = 4,
+        SEEK_HOLE = 3,
+        SEEK_END = 2,
+        SEEK_CUR = 1,
+    },
+    mode = {
+        S_IWGRP = 16,
+        S_IXGRP = 8,
+        S_IROTH = 4,
+        S_IXOTH = 1,
+        S_IRUSR = 256,
+        S_IXUSR = 64,
+        S_IRWXU = 448,
+        S_IRWXG = 56,
+        S_IWOTH = 2,
+        S_IRWXO = 7,
+        S_IWUSR = 128,
+        S_IRGRP = 32,
+    },
+    flag = {
+        O_EXCL = 2048,
+        O_NONBLOCK = 4,
+        O_RDONLY = 0,
+        O_CLOEXEC = 16777216,
+        O_SYNC = 128,
+        O_NDELAY = 4,
+        O_WRONLY = 1,
+        O_TRUNC = 1024,
+        O_NOFOLLOW = 256,
+        O_RDWR = 2,
+        O_ASYNC = 64,
+        O_CREAT = 512,
+        O_APPEND = 8,
+        O_DIRECTORY = 1048576,
+        O_NOCTTY = 131072,
+    }
+}
+
+return fio

--- a/tarantool-annotations/Library/json.lua
+++ b/tarantool-annotations/Library/json.lua
@@ -1,0 +1,87 @@
+---@meta
+
+local json = {}
+
+---@class json.cfg
+---@field encode_max_depth? number (default: 128) Max recursion depth for encoding
+---@field encode_deep_as_nil? boolean (default: false) A flag saying whether to crop tables with nesting level deeper than cfg.encode_max_depth. Not-encoded fields are replaced with one null. If not set, too deep nesting is considered an error.
+---@field encode_invalid_numbers? boolean (deafult: true) A flag saying whether to enable encoding of NaN and Inf numbers
+---@field encode_number_precision? number (default: 14) Precision of floating point numbers
+---@field encode_load_metatables? boolean (default: true) A flag saying whether the serializer will follow __serialize metatable field
+---@field encode_use_tostring? boolean (default: false) A flag saying whether to use tostring() for unknown types
+---@field encode_invalid_as_nil? boolean (default: false) A flag saying whether use NULL for non-recognized types
+---@field encode_sparse_convert? boolean (default: true) A flag saying whether to handle excessively sparse arrays as maps. See detailed description below.
+---@field encode_sparse_ratio? number (default: 2) 1/encode_sparse_ratio is the permissible percentage of missing values in a sparse array.
+---@field encode_sparse_safe? number (default: 10) A limit ensuring that small Lua arrays are always encoded as sparse arrays (instead of generating an error or encoding as a map)
+---@field decode_invalid_numbers? boolean (default: true) A flag saying whether to enable decoding of NaN and Inf numbers
+---@field decode_save_metatables? boolean (default: true) A flag saying whether to set metatables for all arrays and maps
+---@field decode_max_depth? number (default: 128) Max recursion depth for decoding
+
+---Set values that affect the behavior of `json.encode` and `json.decode`
+---
+---The values are all either integers or boolean `true`/`false`.
+---
+---@param cfg json.cfg
+function json.cfg(cfg) end
+
+---Convert a Lua object to a JSON string.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> json.encode(setmetatable({'A', 'B'}, { __serialize="seq"}))
+--- ---
+--- - '["A","B"]'
+--- ...
+--- tarantool> json.encode(setmetatable({'A', 'B'}, { __serialize="map"}))
+--- ---
+--- - '{"1":"A","2":"B"}'
+--- ...
+--- tarantool> json.encode({setmetatable({f1 = 'A', f2 = 'B'}, { __serialize="map"})})
+--- ---
+--- - '[{"f2":"B","f1":"A"}]'
+--- ...
+--- tarantool> json.encode({setmetatable({f1 = 'A', f2 = 'B'}, { __serialize="seq"})})
+--- ---
+--- - '[[]]'
+--- ...
+--- ```
+---
+---@param value any either a scalar value or a Lua table value
+---@param cfg? json.cfg configuration
+---@return string
+function json.encode(value, cfg) end
+
+---Convert a JSON string to a Lua object.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> json = require('json')
+--- ---
+--- ...
+--- tarantool> json.decode('123')
+--- ---
+--- - 123
+--- ...
+--- tarantool> json.decode('[123, "hello"]')
+--- ---
+--- - [123, 'hello']
+--- ...
+--- tarantool> json.decode('{"hello": "world"}').hello
+--- ---
+--- - world
+--- ...
+--- ```
+---
+--- See the tutorial [`Sum a JSON field for all tuples`](doc://c_lua_tutorial-sum_a_json_field>) to see how `json.decode()` can fit in an application.
+---
+---@param str string a string formatted as JSON
+---@param cfg? json.cfg configuration
+---@return any
+function json.decode(str, cfg) end
+
+---A value comparable to Lua "nil" which may be useful as a placeholder in a tuple.
+json.NULL = box.NULL
+
+return json

--- a/tarantool-annotations/Library/log.lua
+++ b/tarantool-annotations/Library/log.lua
@@ -1,0 +1,166 @@
+---@meta
+
+---@class log
+local log = {}
+
+---Log a message with the warn level.
+---
+---* A message can be a string.
+---* A message may contain C-style format specifiers `%d` or `%s`. Example:
+---* A message may be a scalar data type or a table. Example:
+---
+---The actual output will be a line in the log, containing:
+---* The current timestamp
+---* A module name
+---* 'E', 'W', 'I', 'V' or 'D' depending on the called function.
+---* `message`.
+---
+---**Example:**
+---
+--- ```lua
+--- local log = require('log')
+--- log.cfg { level = 'verbose' }
+--- log.warn('Warning message')
+--- log.info('Tarantool version: %s', box.info.version)
+--- log.error({ 500, 'Internal error' })
+--- log.debug('Debug message')
+--- ```
+---
+---Note that the message will not be logged if the severity level corresponding to the called function is less than [`log.level`](doc://configuration_reference_log_level).
+---
+---@param s any
+---@param ... any
+function log.warn(s, ...) end
+
+---Log a message with the info level.
+---
+---* A message can be a string.
+---* A message may contain C-style format specifiers `%d` or `%s`. Example:
+---* A message may be a scalar data type or a table. Example:
+---
+---The actual output will be a line in the log, containing:
+---* The current timestamp
+---* A module name
+---* 'E', 'W', 'I', 'V' or 'D' depending on the called function.
+---* `message`.
+---
+---**Example:**
+---
+--- ```lua
+--- local log = require('log')
+--- log.cfg { level = 'verbose' }
+--- log.warn('Warning message')
+--- log.info('Tarantool version: %s', box.info.version)
+--- log.error({ 500, 'Internal error' })
+--- log.debug('Debug message')
+--- ```
+---
+---Note that the message will not be logged if the severity level corresponding to the called function is less than [`log.level`](doc://configuration_reference_log_level).
+---
+---@param s any
+---@param ... any
+function log.info(s, ...) end
+
+---Log a message with the error level.
+---
+---* A message can be a string.
+---* A message may contain C-style format specifiers `%d` or `%s`. Example:
+---* A message may be a scalar data type or a table. Example:
+---
+---The actual output will be a line in the log, containing:
+---* The current timestamp
+---* A module name
+---* 'E', 'W', 'I', 'V' or 'D' depending on the called function.
+---* `message`.
+---
+---**Example:**
+---
+--- ```lua
+--- local log = require('log')
+--- log.cfg { level = 'verbose' }
+--- log.warn('Warning message')
+--- log.info('Tarantool version: %s', box.info.version)
+--- log.error({ 500, 'Internal error' })
+--- log.debug('Debug message')
+--- ```
+---
+---Note that the message will not be logged if the severity level corresponding to the called function is less than [`log.level`](doc://configuration_reference_log_level).
+---
+---@param s any
+---@param ... any
+function log.error(s, ...) end
+
+---Log a message with the verbose level.
+---
+---* A message can be a string.
+---* A message may contain C-style format specifiers `%d` or `%s`. Example:
+---* A message may be a scalar data type or a table. Example:
+---
+---The actual output will be a line in the log, containing:
+---* The current timestamp
+---* A module name
+---* 'E', 'W', 'I', 'V' or 'D' depending on the called function.
+---* `message`.
+---
+---**Example:**
+---
+--- ```lua
+--- local log = require('log')
+--- log.cfg { level = 'verbose' }
+--- log.warn('Warning message')
+--- log.info('Tarantool version: %s', box.info.version)
+--- log.error({ 500, 'Internal error' })
+--- log.debug('Debug message')
+--- ```
+---
+---Note that the message will not be logged if the severity level corresponding to the called function is less than [`log.level`](doc://configuration_reference_log_level).
+---
+---@param s any
+---@param ... any
+function log.verbose(s, ...) end
+
+---Log a message with the debug level.
+---
+---* A message can be a string.
+---* A message may contain C-style format specifiers `%d` or `%s`. Example:
+---* A message may be a scalar data type or a table. Example:
+---
+---The actual output will be a line in the log, containing:
+---* The current timestamp
+---* A module name
+---* 'E', 'W', 'I', 'V' or 'D' depending on the called function.
+---* `message`.
+---
+---**Example:**
+---
+--- ```lua
+--- local log = require('log')
+--- log.cfg { level = 'verbose' }
+--- log.warn('Warning message')
+--- log.info('Tarantool version: %s', box.info.version)
+--- log.error({ 500, 'Internal error' })
+--- log.debug('Debug message')
+--- ```
+---
+---Note that the message will not be logged if the severity level corresponding to the called function is less than [`log.level`](doc://configuration_reference_log_level).
+---
+---@param s any
+---@param ... any
+function log.debug(s, ...) end
+
+---Set log level.
+---
+---@param lvl? number
+function log.level(lvl) end
+
+---Create a new logger with the specified name.
+---
+---*Since 2.11.0*
+---
+---You can configure a specific log level for a new logger using the `log.modules` configuration property.
+---
+---@param name string
+---@return log
+function log.new(name) end
+
+return log

--- a/tarantool-annotations/Library/net/box.lua
+++ b/tarantool-annotations/Library/net/box.lua
@@ -1,0 +1,248 @@
+---@meta
+
+---# Builtin `net.box` module.
+---
+---The `net.box` module contains connectors to remote database systems. One variant is for connecting to MySQL or MariaDB or PostgreSQL (see [SQL DBMS modules](doc://dbms_modules) reference).
+---
+---The other variant, which is discussed in this section, is for connecting to Tarantool server instances via a network.
+local net_box = {}
+
+---@class net.box.conn
+---@field public host string
+---@field public port string
+---@field public state 'active' | 'fetch_schema' | 'error' | 'error_reconnect' | 'closed' | 'initial' | 'graceful_shutdown'
+---@field public error string
+---@field public peer_uuid? string
+---@field public _fiber? Fiber
+local conn = {}
+
+---@class net.box.request.options
+---@field public is_async? boolean
+---@field public timeout? number
+
+---@class net.box.call.options
+---@field timeout number? Timeout of Call
+---@field is_async boolean? makes request asynchronous
+---@field return_raw boolean? returns raw msgpack (since version 2.10.0)
+---@field on_push fun(ctx: any?, msg: any)? callback for each inbound message
+---@field on_push_ctx any? ctx for on_push callback
+
+---Execute a remote call.
+---
+---`conn:call('func', {'1', '2', '3'})` is the remote-call equivalent of `func('1', '2', '3')`. That is, `conn:call` is a remote stored-procedure call. The return from `conn:call` is whatever the function returns.
+---
+---Limitation: the called function cannot return a function, for example if `func2` is defined as `function func2 () return func end` then `conn:call(func2)` will return "error: unsupported Lua type 'function'".
+---
+---**Examples:**
+---
+--- ```lua
+--- tarantool> -- create 2 functions with conn:eval()
+--- tarantool> conn:eval('function f1() return 5+5 end;')
+--- tarantool> conn:eval('function f2(x,y) return x,y end;')
+--- tarantool> -- call first function with no parameters and no options
+--- tarantool> conn:call('f1')
+--- ---
+--- - 10
+--- ...
+--- tarantool> -- call second function with two parameters and one option
+--- tarantool> conn:call('f2',{1,'B'},{timeout=99})
+--- ---
+--- - 1
+--- - B
+--- ...
+--- ```
+---
+---@async
+---@param func string
+---@param args? any[]
+---@param opts? net.box.call.options
+---@return table
+function conn:call(func, args, opts) end
+
+---Execute Lua code remotely.
+---
+---`conn:eval({Lua-string})` evaluates and executes the expression in Lua-string, which may be any statement or series of statements.
+---An [execute privilege](doc://authentication-owners_privileges) is required; if the user does not have it, an administrator may grant it with `box.schema.user.grant({username}, 'execute', 'universe')`.
+---
+---To ensure hat the return from `conn:eval` is whatever the Lua expression returns, begin the Lua-string with the word "return".
+---
+---**Examples:**
+---
+--- ```lua
+--- tarantool> --Lua-string
+--- tarantool> conn:eval('function f5() return 5+5 end; return f5();')
+--- ---
+--- - 10
+--- ...
+--- tarantool> --Lua-string, {arguments}
+--- tarantool> conn:eval('return ...', {1,2,{3,'x'}})
+--- ---
+--- - 1
+--- - 2
+--- - [3, 'x']
+--- ...
+--- tarantool> --Lua-string, {arguments}, {options}
+--- tarantool> conn:eval('return {nil,5}', {}, {timeout=0.1})
+--- ---
+--- - [null, 5]
+--- ...
+--- ```
+---
+---@async
+---@param expression string
+---@param args any[]?
+---@param opts net.box.call.options?
+---@return table
+function conn:eval(expression, args, opts) end
+
+---Execute a PING command.
+---
+---@async
+---@param opts? { timeout: number }
+---@return boolean
+function conn:ping(opts) end
+
+---Define a trigger for execution when a new connection is established, and authentication and schema fetch are completed due to an event such as `net_box.connect`.
+---
+---If a trigger function issues `net_box` requests, they must be [asynchronous](net.box.is_async) (`{is_async = true}`). An attempt to wait for request completion with `future:pairs()` or `future:wait_result()` in the trigger function will result in an error.
+---
+---If the trigger execution fails and an exception happens, the connection's state changes to 'error'. In this case, the connection is terminated, regardless of the `reconnect_after` option's value. Can be called as many times as reconnection happens, if `reconnect_after` is greater than zero.
+---
+---@param new_callback fun(conn: net.box.conn)
+---@param old_callback? fun(conn: net.box.conn)
+function conn:on_connect(new_callback, old_callback) end
+
+---Define a trigger for execution after a connection is closed.
+---
+---If the trigger function causes an error, the error is logged but otherwise is ignored.
+---
+---Execution stops after a connection is explicitly closed, or once the Lua garbage collector removes it.
+---
+---@param new_callback fun(conn: net.box.conn)
+---@param old_callback? fun(conn: net.box.conn)
+function conn:on_disconnect(new_callback, old_callback) end
+
+---Wait for connection to be active or closed.
+---
+---**Example:**
+---
+--- ```lua
+--- net_box.self:wait_connected()
+--- ```
+---
+---@async
+---@param wait_timeout number
+---@return boolean is_connected true when connected, false on failure.
+function conn:wait_connected(wait_timeout) end
+
+---Close a connection.
+---
+---Connection objects are destroyed by the Lua garbage collector, just like any other objects in Lua, so an explicit destruction is not mandatory. However, since `close()` is a system call, it is good programming practice to close a connection explicitly when it is no longer needed, to avoid lengthy stalls of the garbage collector.
+---
+---**Example:**
+---
+--- ```lua
+--- conn:close()
+--- ```
+---
+function conn:close() end
+
+---Show whether connection is active or closed.
+---
+---@return boolean
+function conn:is_connected() end
+
+---@class net.box.connect.options
+---@field public wait_connected? boolean|number
+---@field public reconnect_after? number
+---@field public user? string
+---@field public password? string
+---@field public connect_timeout? number
+
+---Creates a new connection to Tarantool.
+---
+---The connection is established on demand, at the time of the first request.
+---
+---It can be re-established automatically after a disconnect (see `reconnect_after` option below).
+---
+---The returned `conn` object supports methods for making remote requests, such as `select`, `update` or `delete`.
+---
+---If `reconnect_after` is greater than zero, then `wait_connected` ignores transient failures.
+---The wait completes once the connection is established or is closed explicitly.
+---
+---* `reconnect_after`: a number of seconds to wait before reconnecting.
+---
+---The default value, as with the other `connect` options, is `nil`. If `reconnect_after` is greater than zero, then a `net.box` instance will attempt to reconnect if a connection is lost or a connection attempt fails. This makes transient network failures transparent to the application.
+---
+---Reconnection happens automatically in the background, so requests that initially fail due to connection drops fail, are transparently retried. The number of retries is unlimited, connection retries are made after any specified interval (for example, `reconnect_after=5` means that reconnect attempts are made every 5 seconds).
+---When a connection is explicitly closed or when the Lua garbage collector removes it, then reconnect attempts stop.
+---
+---* `connect_timeout`: a number of seconds to wait before returning "error: Connection timed out".
+---* `fetch_schema`: a boolean option that controls fetching schema changes from the server. Default: `true`.
+---If you don't operate with remote spaces, for example, run only `call` or `eval`, set `fetch_schema` to false` to avoid fetching schema changes which is not needed in this case.
+---
+---**Important:** In connections with `fetch_schema == false`, remote spaces are unavailable and the [`on_schema_reload`](lua://<net.box.on_schema_reload) triggers don't work.
+---
+---* `required_protocol_version`: a minimum version of the [IPROTO protocol](doc://box_protocol-id) supported by the server. If the version of the [IPROTO protocol](doc://box_protocol-id) supported by the server is lower than specified, the connection will fail with an error message.
+---
+---With `required_protocol_version = 1`, all connections fail where the [IPROTO protocol](doc://box_protocol-id) version is lower than `1`.
+---
+---* `required_protocol_features`: specified [IPROTO protocol features](doc://box_protocol-id) supported by the server.
+---You can specify one or more `net.box` features from the table below. If the server does not support the specified features, the connection will fail with an error message.
+---
+---With `required_protocol_features = {'transactions'}`, all connections fail where the server has `transactions: false`.
+---
+---*  net.box feature
+---   Use
+---   IPROTO feature ID
+---   IPROTO versions supporting the feature
+---* `streams`
+---   Requires streams support on the server
+---   IPROTO_FEATURE_STREAMS
+---   1 and newer
+---* `transactions`
+---   Requires transactions support on the server
+---   IPROTO_FEATURE_TRANSACTIONS
+---   1 and newer
+---* `error_extension`
+---   Requires support for [`MP_ERROR`](lua://msgpack.ext.error) MsgPack extension on the server
+---   IPROTO_FEATURE_ERROR_EXTENSION
+---   2 and newer
+---* `watchers`
+---   Requires remote [`watchers`](lua://net.boxwatch) support on the server
+---   IPROTO_FEATURE_WATCHERS
+---   3 and newer
+---
+---To learn more about IPROTO features, see [`IPROTO_ID`](box.protocol.id) and the [`IPROTO_FEATURES]`(doc://internals-iproto-keys-features) key.
+---
+---**Examples:**
+---
+--- ```lua
+--- net_box = require('net.box')
+--- 
+--- conn = net_box.connect('localhost:3301')
+--- conn = net_box.connect('127.0.0.1:3302', {wait_connected = false})
+--- conn = net_box.connect('127.0.0.1:3304', {required_protocol_version = 4, required_protocol_features = {'transactions', 'streams'}, })
+--- ```
+---
+---@async
+---@param endpoint uri_like
+---@param options? net.box.connect.options
+---@return net.box.conn
+function net_box.connect(endpoint, options) end
+
+---Creates connection to Tarantool.
+---
+---`new()` is a synonym for `connect()`. It is retained for backward compatibility.
+---
+---For more information, see the description of [`net_box.connect()`](net.box.connect).
+---
+---@see net.box.connect
+---
+---@async
+---@param endpoint string
+---@param options net.box.connect.options
+---@return net.box.conn
+function net_box.new(endpoint, options) end
+
+return net_box

--- a/tarantool-annotations/Library/string.lua
+++ b/tarantool-annotations/Library/string.lua
@@ -1,0 +1,210 @@
+---@meta
+
+---Split input-string into one or more output strings in a table.
+---
+---The places to split are the places where split-string occurs.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> string = require('string')
+--- ---
+--- ...
+--- tarantool> string.split("A:B:C:D:F", ":", 2)
+--- ---
+--- - - A
+---   - B
+---   - C:D:F
+--- ...
+--- ```
+---
+---@param input_string string the string to split
+---@param split_string? string (default: ' ') the string to find within input-string
+---@param max? number  maximum number of delimiters to process counting from the beginning of the input string. Result will contain max + 1 parts maximum.
+---@return string[] # list of strings
+function string.split(input_string, split_string, max) end
+
+---Return the string left-justified in a string of length `width`.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> string = require('string')
+--- ---
+--- ...
+--- tarantool> string.ljust(' A', 5)
+--- ---
+--- - ' A   '
+--- ...
+--- ```
+---
+---@param input_string string the string to left-justify
+---@param width number the width of the string after left-justifying
+---@param pad_character? string (default: ' ') a single character
+---@return string
+function string.ljust(input_string, width, pad_character) end
+
+---Return the string right-justified in a string of length `width`.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> string = require('string')
+--- ---
+--- ...
+--- tarantool> string.rjust('', 5, 'X')
+--- ---
+--- - 'XXXXX'
+--- ...
+--- ```
+---
+---@param input_string string the string to right-justify
+---@param width number the width of the string after right-justifying
+---@param pad_character? string (default: ' ') a single character
+---@return string
+function string.rjust(input_string, width, pad_character) end
+
+---Return the hexadecimal value of the input string.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> string = require('string')
+--- ---
+--- ...
+--- tarantool> string.hex('ABC ')
+--- ---
+--- - '41424320'
+--- ...
+--- ```
+---
+---@param input_string string
+---@return string
+function string.hex(input_string) end
+
+---Given a string containing pairs of hexadecimal digits, return a string with one byte for each pair.
+---
+---This is the reverse of `string.hex()`.
+---
+---The hexadecimal-input-string must contain an even number of hexadecimal digits.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> string = require('string')
+--- ---
+--- ...
+--- tarantool> string.fromhex('41424320')
+--- ---
+--- - 'ABC '
+--- ...
+--- ```
+---
+---@param input_string string
+---@return string
+function string.fromhex(input_string) end
+
+---Return `true` if input-string starts with start-string, otherwise return `false`.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> string = require('string')
+--- ---
+--- ...
+--- tarantool> string.startswith(' A', 'A', 2, 5)
+--- ---
+--- - true
+--- ...
+--- ```
+---
+---@param input_string string the string where start-string should be looked for
+---@param start_string string the string to look for
+---@param start_pos? integer position: where to start looking within input-string
+---@param end_pos? integer position: where to end looking within input-string
+---@return boolean
+function string.startswith(input_string, start_string, start_pos, end_pos) end
+
+---Return `true` if input-string ends with end-string, otherwise return `false`.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> string = require('string')
+--- ---
+--- ...
+--- tarantool> string.endswith('Baa', 'aa')
+--- ---
+--- - true
+--- ...
+--- ```
+---
+---@param input_string string the string where start-string should be looked for
+---@param start_string string the string to look for
+---@param start_pos? integer position: where to start looking within input-string
+---@param end_pos? integer position: where to end looking within input-string
+---@return boolean
+function string.endswith(input_string, start_string, start_pos, end_pos) end
+
+---Return the value of the input string, after removing characters on the left.
+---
+---The optional `list-of-characters` parameter is a set not a sequence, so `string.lstrip(...,'ABC')` does not mean strip `'ABC'`, it means strip `'A'` or `'B'` or `'C'`.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> string = require('string')
+--- ---
+--- ...
+--- tarantool> string.lstrip(' ABC ')
+--- ---
+--- - 'ABC '
+--- ...
+--- ```
+---
+---@param input_string string the string to process
+---@param list_of_characters string (default: ' ') what characters can be stripped.
+---@return string
+function string.lstrip(input_string) end
+
+---Return the value of the input string, after removing characters on the right.
+---
+---The optional `list-of-characters` parameter is a set not a sequence, so `string.rstrip(...,'ABC')` does not mean strip `'ABC'`, it means strip `'A'` or `'B'` or `'C'`.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> string = require('string')
+--- ---
+--- ...
+--- tarantool> string.rstrip(' ABC ')
+--- ---
+--- - ' ABC'
+--- ...
+--- ```
+---
+---@param input_string string the string to process
+---@param list_of_characters string (default: ' ') what characters can be stripped.
+---@return string
+function string.rstrip(input_string) end
+
+---Return the value of the input string, after removing characters on the left and the right.
+---
+---The optional `list-of-characters` parameter is a set not a sequence, so `string.strip(...,'ABC')` does not mean strip `'ABC'`, it means strip `'A'` or `'B'` or `'C'`.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> string = require('string')
+--- ---
+--- ...
+--- tarantool> string.strip(' ABC ')
+--- ---
+--- - ABC
+--- ...
+--- ```
+---
+---@param input_string string the string to process
+---@param list_of_characters string (default: ' ') what characters can be stripped.
+---@return string
+function string.strip(input_string) end

--- a/tarantool-annotations/Library/tarantool.lua
+++ b/tarantool-annotations/Library/tarantool.lua
@@ -1,0 +1,235 @@
+---@meta
+
+---@alias integer64 ffi.cdata*
+---@alias float64 ffi.cdata*
+
+---@alias scalar
+---| nil # box.NULL or Lua nil
+---| boolean # true/false
+---| string # lua string
+---| integer # lua number
+---| integer64 # luajit cdata
+---| number # lua number
+---| float64 # luajit cdata
+---| decimal # Tarantool decimal
+---| datetime # Tarantool datetime
+---| interval # Tarantool interval
+---| uuid # Tarantool uuid
+
+---@alias compound
+---| map # Tarantool map
+---| array # Tarantool arr
+
+---@alias tuple_type scalar | compound
+---@alias tuple_type_name 'unsigned' | 'string' | 'boolean' | 'number' | 'integer' | 'decimal' | 'varbinary' | 'uuid' | 'scalar' | 'array'
+
+---@alias map table<string, tuple_type> Tarantool kv map, keys are always strings
+---@alias array tuple_type[] Tarantool array
+
+---Convert a string or a Lua number to a 64-bit integer.
+---
+---@param value string|number
+---@return ffi.cdata*|number
+function tonumber64(value) end
+
+---Allocates a new Lua table.
+---
+---@param narr number
+---@param nrec number
+---@return table
+function table.new(narr, nrec) end
+
+---Perform a deep copy of the table
+---
+---Return a "deep" copy of the table -- a copy which follows nested structures to any depth and does not depend on pointers, it copies the contents.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> input_table = {1,{'a','b'}}
+--- ---
+--- ...
+---
+--- tarantool> output_table = table.deepcopy(input_table)
+--- ---
+--- ...
+---
+--- tarantool> output_table
+--- ---
+--- - - 1
+--- - - a
+--- - b
+--- ...
+--- ```
+---
+---@param t table
+---@return table
+function table.deepcopy(t) end
+
+---Perform a shallow copy of the table
+---
+---@see table.deepcopy
+---
+---@param t table
+---@return table
+function table.copy(t) end
+
+---Removes all keys from table.
+---
+---@param t table
+function table.clear(t) end
+
+---Constant `box.NULL`
+---
+---There are some major problems with using Lua `nil` values in tables. For example: you can't correctly assess the length of a table that is not a sequence. (Learn more about data types in [Lua](https://www.lua.org/manual/5.1/manual.html#2.2) and [LuaJIT](http://luajit.org/ext_ffi_semantics.html))
+---
+--- ```tarantoolsession
+--- tarantool> t = {0, nil, 1, 2, nil}
+--- ---
+--- ...
+---
+--- tarantool> t
+--- ---
+--- - - 0
+--- - null
+--- - 1
+--- - 2
+--- ...
+---
+--- tarantool> #t
+--- ---
+--- - 4
+--- ...
+---
+--- ```
+---
+---The console output of `t` processes `nil` values in the middle and at the end of the table differently. This is due to undefined behavior.
+---
+---**Note:** Trying to find the length for sparse arrays in LuaJIT leads to another scenario of [undefined behavior](https://www.lua.org/manual/5.1/manual.html#2.5.5). To avoid this problem, use Tarantool's `box.NULL` constant instead of `nil`. `box.NULL` is a placeholder for a `nil` value in tables to preserve a key without a value.
+---
+---**Using `box.NULL`:**
+---
+---`box.NULL` is a value of the [cdata](http://luajit.org/ext_ffi_semantics.html) type representing a NULL pointer. It is similar to `msgpack.NULL`, `json.NULL` and `yaml.NULL`. So it is some not `nil` value, even if it is a pointer to NULL.
+---
+---Use `box.NULL` only with capitalized NULL (`box.null` is incorrect).
+---
+---**Note:** Technically speaking, `box.NULL` equals to `ffi.cast('void *', 0)`.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> t = {0, box.NULL, 1, 2, box.NULL}
+--- ---
+--- ...
+---
+--- tarantool> t
+--- ---
+--- - - 0
+--- - null # cdata
+--- - 1
+--- - 2
+--- - null # cdata
+--- ...
+---
+--- tarantool> #t
+--- ---
+--- - 5
+--- ...
+---
+--- ```
+---
+---**Note:** Notice that `t[2]` shows the same `null` output in both examples. However in this example `t[2]` and `t[5]` are of the cdata type, while in the previous example their type was `nil`.
+---
+---**Important:**
+---
+---Avoid using implicit comparisons with nullable values when using `box.NULL`. Due to [Lua behavior](https://www.lua.org/manual/5.1/manual.html#2.4.4) returning anything except `false` or `nil` from a condition expression is considered as `true`. And, as it was mentioned earlier, `box.NULL` is a pointer by design.
+---
+---That is why the expression `box.NULL` will always be considered `true` in case it is used as a condition in a comparison. This means that the code
+---
+---`if box.NULL then func() end`
+---
+---will always execute the function `func()` (because the condition `box.NULL` will always be neither `false` nor `nil`).
+---
+---**Distinction of `nil` and `box.NULL`:**
+---
+---Use the expression `if x == nil` to check if the `x` is either a `nil` or a `box.NULL`.
+---
+---To check whether `x` is a **nil** but not a `box.NULL`, use the following condition expression:
+---
+--- ```lua
+--- type(x) == 'nil'
+--- ```
+---
+---If it's `true`, then `x` is a `nil`, but not a `box.NULL`.
+---
+---You can use the following for `box.NULL`:
+---
+--- ```lua
+---
+--- x == nil and type(x) == 'cdata'
+---
+--- ```
+---
+---If the expression above is **true**, then `x` is a `box.NULL`.
+---
+---**Note:**
+---
+---By converting data to different formats (JSON, YAML, msgpack), you shall expect that it is possible that **nil** in sparse arrays will be converted to `box.NULL`. And it is worth mentioning that such conversion might be unexpected (for example: by sending data via :ref:`net.box <net_box-module> or by obtaining data from [`spaces`](box.space) etc.).
+---
+--- ```tarantoolsession
+--- tarantool> type(({1, nil, 2})[2])
+--- ---
+--- - nil
+--- ...
+---
+--- tarantool> type(json.decode(json.encode({1, nil, 2}))[2])
+--- ---
+--- - cdata
+--- ...
+--- ```
+---
+--- You must anticipate such behavior and use a proper condition expression. Use the explicit comparison `x == nil` for checking for NULL in nullable values. It will detect both **nil** and `box.NULL`.
+---
+---@type ffi.cdata*
+box.NULL = {}
+
+box.NULL
+
+---Parse and execute an arbitrary chunk of Lua code. This function is mainly useful to define and run Lua code without having to introduce changes to the global Lua environment.
+---
+---@param lua_chunk_string string Lua code
+---@param ... any zero or more scalar values which will be appended to
+---@return any ... whatever is returned by the Lua code chunk.
+function dostring(lua_chunk_string, ...) end
+
+---@class int64_t: ffi.cdata*
+---@operator add(int64_t|number): int64_t
+---@operator sub(int64_t|number): int64_t
+---@operator mul(int64_t|number): int64_t
+---@operator div(int64_t|number): int64_t
+---@operator unm: int64_t
+---@operator mod(int64_t|number): int64_t
+---@operator pow(int64_t|number): int64_t
+
+---@class uint64_t: ffi.cdata*
+---@operator add(int64_t|number|uint64_t): uint64_t
+---@operator sub(int64_t|number|uint64_t): uint64_t
+---@operator mul(int64_t|number|uint64_t): uint64_t
+---@operator div(int64_t|number|uint64_t): uint64_t
+---@operator unm: uint64_t
+---@operator mod(int64_t|number|uint64_t): uint64_t
+---@operator pow(int64_t|number|uint64_t): uint64_t
+
+---Returns path of the library.
+---
+---@param name string
+---@return string
+function package.search(name) end
+
+---Sets root for require.
+---
+---@param path ?string
+function package.setsearchroot(path) end
+
+---@type any
+_TARANTOOL = {}

--- a/tarantool-annotations/Library/uri.lua
+++ b/tarantool-annotations/Library/uri.lua
@@ -1,0 +1,192 @@
+---@meta
+
+local uri = {}
+
+---@class uri
+---@field fragment? string string after #
+---@field host? string host (same as Host header in HTTP)
+---@field ipv4? string ipv4 address if was parsed
+---@field ipv6? string ipv6 address if was parsed
+---@field login? string login as for basic auth if was parsed
+---@field password? string password as for basic auth if was parsed
+---@field path? string path in HTTP URI if was parsed
+---@field query? table<string,string[]> query of arguments, values are a list of strings
+---@field scheme? string scheme
+---@field service? string port if was given
+---@field unix? string path to unix socket if was parsed
+
+---Parse a URI string into components.
+---
+---**Example:**
+---
+--- ```lua
+--- local uri = require('uri')
+--- 
+--- parsed_uri = uri.parse('https://www.tarantool.io/doc/latest/reference/reference_lua/http/#api-reference')
+--- --[[
+--- ---
+--- - host: www.tarantool.io
+---   fragment: api-reference
+---   scheme: https
+---   path: /doc/latest/reference/reference_lua/http/
+--- ...
+--- --]]
+--- ```
+---
+---@param uri_string string a Uniform Resource Identifier
+---@return uri
+function uri.parse(uri_string) end
+
+---Construct a URI from the specified components.
+---
+---**Example:**
+---
+--- ```lua
+--- formatted_uri = uri.format({ scheme = 'https',
+---                              host = 'www.tarantool.io',
+---                              path = '/doc/latest/reference/reference_lua/http/',
+---                              fragment = 'api-reference' })
+--- --[[
+--- ---
+--- - https://www.tarantool.io/doc/latest/reference/reference_lua/http/#api-reference
+--- ...
+--- --]]
+--- ```
+---
+---@param uri_format uri a series of name=value pairs, one for each component
+---@param include_password boolean? If this is supplied and is true, then the password component is rendered in clear text, otherwise it is omitted.
+---@return string
+function uri.format(uri_format, include_password) end
+
+---Encode a string using the specified encoding options.
+---
+---*Since 2.11.0*
+---
+---**Examples:**
+---
+--- ```lua
+--- escaped_string = uri.escape('C++')
+--- --[[
+--- ---
+--- - C%2B%2B
+--- ...
+--- --]]
+--- ```
+---
+--- ```lua
+--- escaped_string_url_enc = uri.escape('John Smith', uri.FORM_URLENCODED)
+--- --[[
+--- ---
+--- - John+Smith
+--- ...
+--- --]]
+--- ```
+---
+--- ```lua
+--- local escape_opts = {
+---     plus = true,
+---     unreserved = uri.unreserved("a-z")
+--- }
+--- escaped_string_custom = uri.escape('Hello World', escape_opts)
+--- --[[
+--- ---
+--- - '%48ello+%57orld'
+--- ...
+--- --]]
+--- ```
+---
+---@param str string
+---@param uri_encoding_opts uri.encoding_opt
+---@return string
+function uri.escape(str, uri_encoding_opts) end
+
+---Decode a string using the specified encoding options.
+---
+---*Since 2.11.0*
+---
+--- By default, `uri.escape()` uses encoding options defined by the [`uri.RFC3986`](lua://uri.RFC3986) table.
+---
+--- If required, you can customize encoding options using the `uri_encoding_opts` optional parameter, for example:
+--- * Pass the predefined set of options targeted for encoding a specific URI part (for example, [`uri.PATH`](lua://uri.PATH) or [`uri.QUERY`](lua://lua.QUERY)).
+--- * Pass custom encoding options using the [uri.encoding_opts](uri.encoding_opts) object.
+---
+---**Examples:**
+---
+--- ```lua
+--- unescaped_string = uri.unescape('C%2B%2B')
+--- --[[
+--- ---
+--- - C++
+--- ...
+--- --]]
+--- ```
+---
+--- ```lua
+--- unescaped_string_url_enc = uri.unescape('John+Smith', uri.FORM_URLENCODED)
+--- --[[
+--- ---
+--- - John Smith
+--- ...
+--- --]]
+--- ```
+---
+--- ```lua
+--- local escape_opts = {
+---     plus = true,
+---     unreserved = uri.unreserved("a-z")
+--- }
+--- unescaped_string_custom = uri.unescape('%48ello+%57orld', escape_opts)
+--- --[[
+--- ---
+--- - Hello World
+--- ...
+--- --]]
+--- ```
+---
+---@param str string
+---@param uri_encoding_opts uri.encoding_opt
+---@return string
+function uri.unescape(str, uri_encoding_opts) end
+
+---@class uri.encoding_opt
+
+---Encoding options that use unreserved symbols defined in RFC 3986
+---
+---@type uri.encoding_opt
+uri.RFC3986 = nil
+
+---Options used to encode the `path` URI component
+---
+---@type uri.encoding_opt
+uri.PATH = nil
+
+---Options used to encode specific `path` parts
+---
+---@type uri.encoding_opt
+uri.PATH_PART = nil
+
+---Options used to encode the `query` URI component
+---
+---@type uri.encoding_opt
+uri.QUERY = nil
+
+--- Options used to encode specific `query` parts
+---
+---@type uri.encoding_opt
+uri.QUERY_PART = nil
+
+---Options used to encode the `fragment` URI component
+---
+---@type uri.encoding_opt
+uri.FRAGMENT = nil
+
+---Options used to encode `application/x-www-form-urlencoded` form parameters
+---
+---@type uri.encoding_opt
+uri.FORM_URLENCODED = nil
+
+-- TODO: uri encoding options
+
+---@alias uri_like uri | string
+
+return uri

--- a/tarantool-annotations/Library/uuid.lua
+++ b/tarantool-annotations/Library/uuid.lua
@@ -1,0 +1,140 @@
+---@meta
+
+---# Builtin `uuid` module
+---
+---A "UUID" is a [Universally unique identifier](https://en.wikipedia.org/wiki/Universally_unique_identifier).
+---
+---If an application requires that a value be unique only within a single computer or on a single database, then a simple counter is better than a UUID, because getting a UUID is time-consuming (it requires a [syscall](https://en.wikipedia.org/wiki/Syscall)). For clusters of computers, or widely distributed applications, UUIDs are better.
+---
+---Tarantool generates UUIDs following the rules for RFC 4122 [version 4 variant 1](https://en.wikipedia.org/wiki/Universally_unique_identifier#Versio4_(random)).
+local uuid = {}
+
+---@class uuid: ffi.cdata*
+local uuid_obj = {}
+
+---Create a UUID sequence. You can use it in an index over a uuid field.
+---
+---*Since 2.4.1*
+---
+---For example, to create such index for a space named `test`, say:
+---
+--- ```tarantoolsession
+--- tarantool> box.space.test:create_index("pk", {parts={{field = 1, type = 'uuid'}}})
+--- ```
+---
+---Now you can insert UUIDs into the space:
+---
+--- ```tarantoolsession
+--- tarantool> box.space.test:insert{uuid.new()}
+--- ---
+--- - [e631fdcc-0e8a-4d2f-83fd-b0ce6762b13f]
+--- ...
+---
+--- tarantool> box.space.test:insert{uuid.fromstr('64d22e4d-ac92-4a23-899a-e59f34af5479')}
+--- ---
+--- - [64d22e4d-ac92-4a23-899a-e59f34af5479]
+--- ...
+---
+--- tarantool> box.space.test:select{}
+--- ---
+--- - - [64d22e4d-ac92-4a23-899a-e59f34af5479]
+--- - [e631fdcc-0e8a-4d2f-83fd-b0ce6762b13f]
+--- ...
+--- ```
+---
+---@return uuid
+function uuid.new() end
+
+---@alias uuid.byte_order
+---| "l" # little-endian
+---| "b" # big-endian
+---| "h" # host (endianness depends on host)
+---| "n" # network (endianness depends on network)
+---| "host" # host (endianness depends on host)
+---| "network" # network (endianness depends on network)
+
+---Get UUID as 16-byte string.
+---
+---@param byte_order? uuid.byte_order Byte order of the resulting UUID
+---@return string uuid 16-byte string
+function uuid.bin(byte_order) end
+
+---Convert UUID to a 16-byte string.
+---
+---@param byte_order? uuid.byte_order Byte order of the resulting UUID
+---@return string uuid 16-byte string
+function uuid_obj:bin(byte_order) end
+
+---Get UUID as 36-byte hexademical string.
+---
+---@return string uuid 36-byte binary string
+function uuid.str() end
+
+---Convert UUID to a 36-byte hexademical string.
+---
+---@return string uuid 36-byte binary string
+function uuid_obj:str() end
+
+---Convert hexademical 36-byte string to an UUID object.
+---
+---@param uuid_str string UUID in 36-byte hexadecimal string
+---@return uuid uuid converted UUID
+function uuid.fromstr(uuid_str) end
+
+---Convert binary 16-byte string to an UUID object.
+---
+---@param uuid_bin string UUID in 16-byte binary string
+---@param byte_order? uuid.byte_order Byte order of the resulting UUID
+---@return uuid uuid converted UUID
+function uuid.frombin(uuid_bin, byte_order) end
+
+---Check if the object is UUID.
+---
+---*Since 2.6.1*
+---
+---@param value any
+---@return boolean is_uuid true if the specified value is a uuid, and false otherwise
+function uuid.is_uuid(value) end
+
+---Check if the UUID is `nil`.
+---
+---The all-zero UUID value can be expressed as [`uuid.NULL`](lua://uuid.NULL), or as `uuid.fromstr('00000000-0000-0000-0000-000000000000')`.
+---
+---The comparison with an all-zero value can also be expressed as `uuid_with_type_cdata == uuid.NULL`.
+---
+---**Example:**
+---
+--- ```tarantoolsession
+--- tarantool> uuid = require('uuid')
+--- ---
+--- ...
+--- tarantool> uuid(), uuid.bin(), uuid.str()
+--- ---
+--- - 16ffedc8-cbae-4f93-a05e-349f3ab70baa
+--- - !!binary FvG+Vy1MfUC6kIyeM81DYw==
+--- - 67c999d2-5dce-4e58-be16-ac1bcb93160f
+--- ...
+--- tarantool> uu = uuid()
+--- ---
+--- ...
+--- tarantool> #uu:bin(), #uu:str(), type(uu), uu:isnil()
+--- ---
+--- - 16
+--- - 36
+--- - cdata
+--- - false
+--- ...
+--- ```
+---
+---@param value nilany
+---@return boolean is_nil true if the specified value is a nil uuid, and false otherwise
+function uuid.is_nil(value) end
+
+---Zero UUID.
+---
+---Equivalent to `uuid.fromstr('00000000-0000-0000-0000-000000000000')`.
+---
+---@type uuid
+uuid.NULL = nil
+
+return uuid

--- a/tarantool-annotations/README.md
+++ b/tarantool-annotations/README.md
@@ -1,0 +1,317 @@
+# Tarantool EmmyLua annotations [alpha]
+
+This repository provides experimental EmmyLua annotations for a [Tarantool in-memory computing platform](https://github.com/tarantool/tarantool).
+Using it you may find out how to configure your IDE for developing Tarantool applications with static checks and autocompletion.
+
+For the ones unfamiliar with the LSP and annotations they extend Lua code with type system in the similar way TypeScript does the following to JavaScript. Types don't exist during the Runtime but allows one to statically check the applications.
+
+See the usage section for examples on how to use it.
+
+## Installation (stable)
+
+This path lua-language-server
+
+1. Set up [lua-language-server](https://github.com/LuaLS/lua-language-server) using the [instructions from the official website](https://luals.github.io/#vscode-install).
+    - __VS Code__:
+        Search for "Lua" by sumneko in the extension marketplace. Install it. There you go.
+    - __NeoVim__:
+        If you are new to NeoVim, follow this guide to setup plugin manager and the Tarantool annotations. If you already familiar with this text editor you might proceed to the fourth step.
+
+        Step 1. Setup plugin manager. This guide uses [packer.nvim](https://github.com/wbthomason/packer.nvim) but there might be other options.
+        ```bash
+        git clone --depth 1 https://github.com/wbthomason/packer.nvim ~/.local/share/nvim/site/pack/packer/start/packer.nvim
+        ```
+
+        Step 2. Setup [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/tree/master), [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) and [cmp-nvim-lsp](https://github.com/hrsh7th/cmp-nvim-lsp) plugins. They're needed for easy LSP configuration and for adding completions support. To do this, create `~/.config/nvim/lua/plugins.lua` with the following contents.
+        ```lua
+        -- ~/.config/nvim/lua/plugins.lua
+
+        vim.cmd [[packadd packer.nvim]]
+
+        return require('packer').startup(function(use)
+            use 'wbthomason/packer.nvim'
+            use 'neovim/nvim-lspconfig'
+            use 'hrsh7th/cmp-nvim-lsp'
+            use 'hrsh7th/nvim-cmp'
+        end)
+        ```
+
+        NeoVim supports both Lua and VimScript for its configuration. If you previously used vanilla Vim you might wanna use your `.vimrc`. This can be done using `source` command in the `~/.config/nvim/init.vim` initialization file. You also need to enable the created plugins script using the `lua` command. Create `~/.config/nvim/init.vim` with the following contents.
+        ```vim
+        " ~/.config/nvim/init.vim
+
+        source ~/.vimrc
+
+        lua require('plugins')
+        ```
+
+        Step 3. Run NeoVim and execute `:PackerSync` to install the configured plugins.
+
+        Step 4. Install [Lua Language Server](https://github.com/LuaLS/lua-language-server)
+
+        If you have `homebrew`, `scoop`, `macports` run one of these:
+        ```bash
+        # Scoop
+        scoop install lua-language-server
+
+        # Homebrew
+        brew install lua-language-server
+
+        # Macports
+        sudo port install lua-language-server
+        ```
+
+        Otherwise, install it from the [latest releases](https://github.com/LuaLS/lua-language-server/releases/latest) or build it from sources.
+
+        Step 4. Now you should have all the needed plugins installed. Add this to `~/.config/nvim/lua/config.lua` to set up Lua Language Server for Lua files.
+        ```lua
+        -- ~/.config/nvim/lua/config.lua
+
+        -- Setup Lua Language Server.
+        require'lspconfig'.lua_ls.setup{}
+
+        -- Setup completions and arrows for navigating them.
+        local cmp = require'cmp'
+        cmp.setup({
+            sources = {
+                { name = "nvim_lsp" },
+                { name = "buffer" },
+            },
+            mapping = {
+                ["<cr>"] = cmp.mapping.confirm({select = true}),
+                ["<Up>"] = cmp.mapping.select_prev_item(),
+                ["<Down>"] = cmp.mapping.select_next_item(),
+            },
+        })
+        ```
+        And enable this file inside your initialization `init.vim` file.
+        ```vim
+        " ~/.config/nvim/init.vim
+
+        source ~/.vimrc
+
+        lua require('plugins')
+        lua require('config')
+        ```
+
+        That's it, you now have NeoVim configured for using it with Tarantool annotations.
+    - __JetBrains__:
+        Install [SumnekoLua](https://plugins.jetbrains.com/plugin/22315-sumnekolua) from the plugin marketplace.
+2. Configure LSP to find annotations Library. Create `.luarc.json` inside you Tarantool app (or within the Tarantool sources if you want to use the annotations within the Tarantool repository) with the following contents.
+```json
+{
+  "runtime": {
+    "version": "LuaJIT"
+  },
+  "workspace": {
+    "library": [
+      "<path to the cloned repository>/Library"
+    ]
+  }
+}
+```
+
+For more information on configuring language server refer to the [project's documentation](https://luals.github.io/wiki/configuration/).
+
+## Installation (experimental)
+
+*Note:* [lua-language-server](https://github.com/LuaLS/lua-language-server) is a mature project. Though at the time of publishing this repository it has [poor support of generics](https://github.com/LuaLS/lua-language-server/issues/1861). But using a generic concept is crucial for Tarantool objects. Take [spaces](https://www.tarantool.io/en/doc/latest/platform/ddl_dml/value_store/#index-box-space) as an example. Tarantool spaces are the containers for the data of generic type defined by the user (similarly to the tables storing rows satisfying corresponding to some schema in relational databases). Thus, function for processing the tuples can't be simply implemented without generics.
+
+Since there, there is an experimental solution based on the [emmylua-analyzer-rust project](https://github.com/CppCXY/emmylua-analyzer-rust). Currently, this language server may throw some false-positive warnings. Thus, it's not recommended to use it within the CI. Though it provides better autocompletion, stricter type-checking, and more tools for code analysis (honestly it's also easier to contribute to since it's written in Rust).
+
+1. Install [emmylua-analyzer-rust LSP](https://github.com/CppCXY/emmylua-analyzer-rust).
+2. Configure your text editor to use it.
+If you're using NeoVim, put this in your Lua configuration:
+```lua
+vim.lsp.start({
+  cmd = { "emmylua_ls" },
+  root_dir = vim.fn.getcwd(),
+})
+```
+If you're using VSCode, install an extension [https://marketplace.visualstudio.com/items?itemName=tangzx.emmylua](https://marketplace.visualstudio.com/items?itemName=tangzx.emmylua).
+
+3. Clone the annotations repository
+```bash
+git clone https://github.com/georgiy-belyanin/tarantool-emmylua
+```
+4. Configure LSP to find annotations Library. Create `.emmyrc.json` with the following contents.
+```json
+{
+  "runtime": {
+    "version": "LuaJIT"
+  },
+  "workspace": {
+    "library": [
+      "<path to the cloned repository>/Library"
+    ]
+  }
+}
+```
+
+For more information on configuring language sesrver refer to the [project's documentation](https://github.com/CppCXY/emmylua-analyzer-rust/blob/main/docs/config/emmyrc_json_EN.md).
+
+## Usage
+
+After installing text-editor-specific IDE provides documentation and completion for the most popular Tarantool functions. For instance, pressing `K` in NeoVim having a Tarantool call under the cursor displays a documentation and information on the arguments and return types. This is a piece of the documentation for `fiber.new()`.
+
+```markdown
+Create a fiber but do not start it.
+
+The created fiber starts after the fiber creator (that is, the job that is calling `fiber.new()`) yields. The initial fiber state is ready.
+
+**Note:** `fiber.status()` returns the suspended state for ready fibers because the ready state is not observable using the fiber module API.
+
+You can join fibers created using `fiber.new()` by calling the `fiber_object:join()` function and get the result returned by the fiber's function.
+
+To join the fiber, you need to make it joinable using `fiber_object:set_joinable()`.
+```
+
+You might want to include annotations for user-defined functions and data types.
+
+```lua
+-- Define type aliases for the user-defined types.
+
+---@alias deposit_tuple [number, string, number]
+
+-- You may define custom classes with fields and inherit them one from another.
+
+---@class deposit: table
+---@field id number ID of the deposit.
+---@field owner string Owner's name.
+---@field amount number Amount.
+
+-- Define type annotations for the user-defined calls.
+
+---The call processes a deposit tuple. This is a short description.
+---
+---This call really processes a tuple. This is a long description. Believe me.
+---
+---@param t deposit_tuple
+---@return deposit_tuple updated_tuple
+local function process_tuple(t)
+    return {t[1], t[2], t[3] + 1000}
+end
+
+-- Warning: wrong arument type.
+local tuple_1 = process_tuple({1, 2, 3})
+-- Ok.
+local tuple_2 = process_tuple({1, 'Stan', 1000})
+
+-- Define types for the user-defined variables.
+
+---@type deposit
+local stan_deposit = { id = 1, owner = 'Stan', amount = 1000 }
+```
+
+If you use experimental [emmylua-analyzer-rust](https://github.com/CppCXY/emmylua-analyzer-rust) as a language server you may annotate your spaces by defining a project-specific language server definition file with similar generic type annotations.
+
+```lua
+---@meta
+
+--Define the types used within the space.
+
+---@alias deposit_tuple [number, string, number]
+---@alias deposit { id: number, owner: string, amount: number }
+
+--Define the space type itself.
+
+---@type box.space<deposit_tuple, deposit>
+box.space.deposits = {}
+```
+
+LSP now guides you if you're trying to use yielding method implicitly.
+
+```lua
+local function is_it_yield()
+    -- Warning: using an async (~ yielding) function within non-async function.
+    require('net.box').connect('127.0.0.1:3300')
+    -- ...
+end
+
+-- Marking the function with `@async` explicitly allows it to yield.
+
+---@async
+local function is_it_yield()
+    -- Ok.
+    local conn = require('net.box').connect('127.0.0.1:3300')
+    -- ...
+end
+```
+
+[Emmylua-analyzer-rust](https://github.com/CppCXY/emmylua-analyzer-rust) also provides a tool for running CLI checks similar to the ones provided by LSP.
+
+```bash
+# Run CLI checks and linting of the Lua files within the current directory.
+emmylua_check .
+```
+
+For more information on using LSP refer to the [project's documentation](https://github.com/CppCXY/emmylua-analyzer-rust/blob/main/docs/features/features_EN.md).
+
+## Progress
+
+* Builtin Tarantool CE modules
+    - [x] `box` (partial)
+        + [x] `backup`
+        + [x] `cfg`
+        + [x] `ctl` (partial)
+        + [x] `error`
+        + [x] `index` (partial)
+        + [x] `info`
+        + [x] `schema` (partial, `user`/`role` is missing)
+        + [x] `session`
+        + [x] `slab`
+        + [x] `space` (partial)
+        + [x] `stat` (partial)
+        + [x] `tuple`
+    - [ ] `buffer`
+    - [x] `clock`
+    - [x] `console`
+    - [ ] `config`
+    - [ ] `crypto`
+    - [ ] `csv`
+    - [x] `datetime`
+    - [x] `decimal`
+    - [ ] `digest`
+    - [ ] `errno`
+    - [ ] `experimental.connpool`
+    - [x] `fiber`
+    - [x] `fio`
+    - [ ] `fun`
+    - [ ] `http`
+        + [ ] `client`
+        + [ ] `server`
+    - [ ] `iconv`
+    - [ ] `jit`
+    - [x] `json` (partial)
+    - [x] `log`
+    - [ ] `merger`
+    - [ ] `msgpack`
+    - [x] `net.box` (partial)
+    - [ ] `pickle`
+    - [ ] `popen`
+    - [ ] `socket`
+    - [ ] `strict`
+    - [x] `string`
+    - [ ] `tarantool`
+    - [x] `uri`
+    - [ ] `utf8`
+    - [x] `uuid`
+    - [ ] `xlog`
+    - [x] `yaml`
+
+* Popular Tarantool rocks
+    - [ ] `checks`
+    - [ ] `crud`
+    - [ ] `exprationd`
+    - [ ] `luatest`
+    - [ ] `metrics`
+    - [ ] `queue`
+    - [ ] `vshard`
+
+## Contributing
+
+If you have suggestions, ideas, etc. on the Language Server or annotations themselves feel free to leave issues, pull requests and discussions.
+
+## References, see also, acknowledgements
+
+This project is the future development of the [VSCode Tarantool extension](https://github.com/vaintrub/vscode-tarantool/) owned by @vaintrub. Also, thanks @ochaton and @totktonada for writing the annotations and helping to define the shape of the project.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ const extensionConfig = {
   plugins: [
     new CopyWebpackPlugin({
       patterns: [
-        { from: './tarantool-emmylua', to: path.resolve(__dirname, 'dist') }
+        { from: './tarantool-annotations', to: path.resolve(__dirname, 'dist') }
       ]
     })
   ],


### PR DESCRIPTION
This patch makes the extension not use `tarantool-emmylua` as a
submodule. Instead the Tarantool-specific are stored within the
repository in `tarantool-annotations` dir.

- The first patch makes the extension not use tarantool-emmylua as a submodule.
- The second patch makes `init extension` command use the currently opened
  file.
