### PR TITLE
Use LFS in CI git checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+        lfs: true
     - name: Setup node 20.x
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
This patch makes the `actions/checkout` use Git LFS for checking out the
PNG icon and adding it to the artifact.
